### PR TITLE
RedfishClientPkg/ConverterLib: Fix empty string value issue

### DIFF
--- a/RedfishClientPkg/ConverterLib/src/RedfishCsCommon.c
+++ b/RedfishClientPkg/ConverterLib/src/RedfishCsCommon.c
@@ -223,7 +223,7 @@ allocateDuplicateStr (
 {
   RedfishCS_status  Status;
 
-  if ((Str == NULL) || (strlen (Str) == 0)) {
+  if (Str == NULL) {
     *DstBuffer = NULL;
     return RedfishCS_status_success;
   }


### PR DESCRIPTION
allocateDuplicateStr() will not copy input string when input string is empty string. It returns NULL pointer and creates assertion in application driver.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Reviewed-by: Abner Chang <abner.chang@amd.com>