### PR TITLE
Fix RedfishClientPkg build errors

### DIFF
--- a/RedfishClientPkg/ConverterLib/edk2library/Bios/v1_0_9/Lib.inf
+++ b/RedfishClientPkg/ConverterLib/edk2library/Bios/v1_0_9/Lib.inf
@@ -1,5 +1,6 @@
 #
 #  (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # Auto-generated file by Redfish Schema C Structure Generator.
@@ -47,5 +48,4 @@ LIBRARY_CLASS                  = BiosV1_0_9Lib | DXE_DRIVER UEFI_APPLICATION UEF
   #   C4706: assignment within conditional expression
   #
   MSFT:*_*_*_CC_FLAGS = /wd4706
-
-
+  GCC:*_*_*_CC_FLAGS = -Wno-unused-but-set-variable

--- a/RedfishClientPkg/ConverterLib/edk2library/ComputerSystem/v1_5_0/Lib.inf
+++ b/RedfishClientPkg/ConverterLib/edk2library/ComputerSystem/v1_5_0/Lib.inf
@@ -1,5 +1,6 @@
 #
 #  (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # Auto-generated file by Redfish Schema C Structure Generator.
@@ -47,5 +48,4 @@ LIBRARY_CLASS                  = ComputerSystemV1_5_0Lib | DXE_DRIVER UEFI_APPLI
   #   C4706: assignment within conditional expression
   #
   MSFT:*_*_*_CC_FLAGS = /wd4706
-
-
+  GCC:*_*_*_CC_FLAGS = -Wno-unused-but-set-variable

--- a/RedfishClientPkg/ConverterLib/edk2library/ComputerSystemCollection/Lib.inf
+++ b/RedfishClientPkg/ConverterLib/edk2library/ComputerSystemCollection/Lib.inf
@@ -1,5 +1,6 @@
 #
 #  (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # Auto-generated file by Redfish Schema C Structure Generator.
@@ -47,5 +48,4 @@ LIBRARY_CLASS                  = ComputerSystemCollectionLib | DXE_DRIVER UEFI_A
   #   C4706: assignment within conditional expression
   #
   MSFT:*_*_*_CC_FLAGS = /wd4706
-
-
+  GCC:*_*_*_CC_FLAGS = -Wno-unused-but-set-variable

--- a/RedfishClientPkg/ConverterLib/edk2library/Memory/v1_7_1/Lib.inf
+++ b/RedfishClientPkg/ConverterLib/edk2library/Memory/v1_7_1/Lib.inf
@@ -1,5 +1,6 @@
 #
 #  (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # Auto-generated file by Redfish Schema C Structure Generator.
@@ -47,5 +48,4 @@ LIBRARY_CLASS                  = MemoryV1_7_1Lib | DXE_DRIVER UEFI_APPLICATION U
   #   C4706: assignment within conditional expression
   #
   MSFT:*_*_*_CC_FLAGS = /wd4706
-
-
+  GCC:*_*_*_CC_FLAGS = -Wno-unused-but-set-variable

--- a/RedfishClientPkg/ConverterLib/edk2library/MemoryCollection/Lib.inf
+++ b/RedfishClientPkg/ConverterLib/edk2library/MemoryCollection/Lib.inf
@@ -1,5 +1,6 @@
 #
 #  (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 # Auto-generated file by Redfish Schema C Structure Generator.
@@ -47,5 +48,4 @@ LIBRARY_CLASS                  = MemoryCollectionLib | DXE_DRIVER UEFI_APPLICATI
   #   C4706: assignment within conditional expression
   #
   MSFT:*_*_*_CC_FLAGS = /wd4706
-
-
+  GCC:*_*_*_CC_FLAGS = -Wno-unused-but-set-variable

--- a/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.c
+++ b/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.c
@@ -2,7 +2,7 @@
   Redfish feature driver implementation - Bios
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+  Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -18,10 +18,10 @@ HandleResource (
   IN  EFI_STRING                       Uri
   );
 
-EFI_HANDLE  medfishResourceConfigProtocolHandle;
+EFI_HANDLE  mRedfishResourceConfigProtocolHandle;
 
 /**
-  Provising redfish resource by given URI.
+  Provisioning redfish resource by given URI.
 
   @param[in]   This                Pointer to EFI_HP_REDFISH_HII_PROTOCOL instance.
   @param[in]   Uri                 Target URI to create resource.
@@ -33,6 +33,7 @@ EFI_HANDLE  medfishResourceConfigProtocolHandle;
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceProvisioningResource (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri,
@@ -94,6 +95,7 @@ RedfishResourceProvisioningResource (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceConsumeResource (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -233,18 +235,15 @@ RedfishResourceConsumeResource (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceGetInfo (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   OUT    REDFISH_SCHEMA_INFO                     *Info
   )
 {
-  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
-
   if ((This == NULL) || (Info == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
-
-  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
 
   AsciiStrCpyS (Info->Schema, REDFISH_SCHEMA_STRING_SIZE, RESOURCE_SCHEMA);
   AsciiStrCpyS (Info->Major, REDFISH_SCHEMA_VERSION_SIZE, RESOURCE_SCHEMA_MAJOR);
@@ -265,6 +264,7 @@ RedfishResourceGetInfo (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceUpdate (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -334,6 +334,7 @@ RedfishResourceUpdate (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceCheck (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -404,6 +405,7 @@ RedfishResourceCheck (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceIdentify (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -478,7 +480,7 @@ EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  mRedfishResourceConfig = {
   handler.
 
   @param[in]   This                     Pointer to EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL instance.
-  @param[in]   RedfishConfigServiceInfo Redfish service informaion.
+  @param[in]   RedfishConfigServiceInfo Redfish service information.
 
   @retval EFI_SUCCESS                  The handler has been initialized successfully.
   @retval EFI_DEVICE_ERROR             Failed to create or configure the REST EX protocol instance.
@@ -799,7 +801,7 @@ RedfishResourceEntryPoint (
     return EFI_ALREADY_STARTED;
   }
 
-  medfishResourceConfigProtocolHandle = ImageHandle;
+  mRedfishResourceConfigProtocolHandle = ImageHandle;
 
   mRedfishResourcePrivate = AllocateZeroPool (sizeof (REDFISH_RESOURCE_COMMON_PRIVATE));
   CopyMem (&mRedfishResourcePrivate->ConfigHandler, &mRedfishConfigHandler, sizeof (EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL));

--- a/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.c
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.c
@@ -2,6 +2,7 @@
   Redfish feature driver implementation - ComputerSystem
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -11,10 +12,10 @@
 
 extern REDFISH_RESOURCE_COMMON_PRIVATE  *mRedfishResourcePrivate;
 
-EFI_HANDLE  medfishResourceConfigProtocolHandle;
+EFI_HANDLE  mRedfishResourceConfigProtocolHandle;
 
 /**
-  Provising redfish resource by given URI.
+  Provisioning redfish resource by given URI.
 
   @param[in]   This                Pointer to EFI_HP_REDFISH_HII_PROTOCOL instance.
   @param[in]   Uri                 Target URI to create resource.
@@ -26,6 +27,7 @@ EFI_HANDLE  medfishResourceConfigProtocolHandle;
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceProvisioningResource (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri,
@@ -87,6 +89,7 @@ RedfishResourceProvisioningResource (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceConsumeResource (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -178,18 +181,15 @@ RedfishResourceConsumeResource (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceGetInfo (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   OUT    REDFISH_SCHEMA_INFO                     *Info
   )
 {
-  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
-
   if ((This == NULL) || (Info == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
-
-  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
 
   AsciiStrCpyS (Info->Schema, REDFISH_SCHEMA_STRING_SIZE, RESOURCE_SCHEMA);
   AsciiStrCpyS (Info->Major, REDFISH_SCHEMA_VERSION_SIZE, RESOURCE_SCHEMA_MAJOR);
@@ -210,6 +210,7 @@ RedfishResourceGetInfo (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceUpdate (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -279,6 +280,7 @@ RedfishResourceUpdate (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceCheck (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -349,6 +351,7 @@ RedfishResourceCheck (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceIdentify (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -423,7 +426,7 @@ EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  mRedfishResourceConfig = {
   handler.
 
   @param[in]   This                     Pointer to EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL instance.
-  @param[in]   RedfishConfigServiceInfo Redfish service informaion.
+  @param[in]   RedfishConfigServiceInfo Redfish service information.
 
   @retval EFI_SUCCESS                  The handler has been initialized successfully.
   @retval EFI_DEVICE_ERROR             Failed to create or configure the REST EX protocol instance.
@@ -613,7 +616,7 @@ RedfishResourceEntryPoint (
     return EFI_ALREADY_STARTED;
   }
 
-  medfishResourceConfigProtocolHandle = ImageHandle;
+  mRedfishResourceConfigProtocolHandle = ImageHandle;
 
   mRedfishResourcePrivate = AllocateZeroPool (sizeof (REDFISH_RESOURCE_COMMON_PRIVATE));
   CopyMem (&mRedfishResourcePrivate->ConfigHandler, &mRedfishConfigHandler, sizeof (EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL));

--- a/RedfishClientPkg/Features/Memory/V1_7_1/Dxe/MemoryDxe.c
+++ b/RedfishClientPkg/Features/Memory/V1_7_1/Dxe/MemoryDxe.c
@@ -2,6 +2,7 @@
   Redfish feature driver implementation - Memory
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -11,10 +12,10 @@
 
 extern REDFISH_RESOURCE_COMMON_PRIVATE  *mRedfishResourcePrivate;
 
-EFI_HANDLE  medfishResourceConfigProtocolHandle;
+EFI_HANDLE  mRedfishResourceConfigProtocolHandle;
 
 /**
-  Provising redfish resource by given URI.
+  Provisioning redfish resource by given URI.
 
   @param[in]   This                Pointer to EFI_HP_REDFISH_HII_PROTOCOL instance.
   @param[in]   Uri                 Target URI to create resource.
@@ -26,6 +27,7 @@ EFI_HANDLE  medfishResourceConfigProtocolHandle;
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceProvisioningResource (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri,
@@ -87,6 +89,7 @@ RedfishResourceProvisioningResource (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceConsumeResource (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -178,18 +181,15 @@ RedfishResourceConsumeResource (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceGetInfo (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   OUT    REDFISH_SCHEMA_INFO                     *Info
   )
 {
-  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
-
   if ((This == NULL) || (Info == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
-
-  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
 
   AsciiStrCpyS (Info->Schema, REDFISH_SCHEMA_STRING_SIZE, RESOURCE_SCHEMA);
   AsciiStrCpyS (Info->Major, REDFISH_SCHEMA_VERSION_SIZE, RESOURCE_SCHEMA_MAJOR);
@@ -210,6 +210,7 @@ RedfishResourceGetInfo (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceUpdate (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -279,6 +280,7 @@ RedfishResourceUpdate (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceCheck (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -349,6 +351,7 @@ RedfishResourceCheck (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishResourceIdentify (
   IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
   IN     EFI_STRING                              Uri
@@ -423,7 +426,7 @@ EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  mRedfishResourceConfig = {
   handler.
 
   @param[in]   This                     Pointer to EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL instance.
-  @param[in]   RedfishConfigServiceInfo Redfish service informaion.
+  @param[in]   RedfishConfigServiceInfo Redfish service information.
 
   @retval EFI_SUCCESS                  The handler has been initialized successfully.
   @retval EFI_DEVICE_ERROR             Failed to create or configure the REST EX protocol instance.
@@ -613,7 +616,7 @@ RedfishResourceEntryPoint (
     return EFI_ALREADY_STARTED;
   }
 
-  medfishResourceConfigProtocolHandle = ImageHandle;
+  mRedfishResourceConfigProtocolHandle = ImageHandle;
 
   mRedfishResourcePrivate = AllocateZeroPool (sizeof (REDFISH_RESOURCE_COMMON_PRIVATE));
   CopyMem (&mRedfishResourcePrivate->ConfigHandler, &mRedfishConfigHandler, sizeof (EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL));

--- a/RedfishClientPkg/Include/Protocol/EdkIIRedfishETagProtocol.h
+++ b/RedfishClientPkg/Include/Protocol/EdkIIRedfishETagProtocol.h
@@ -36,7 +36,7 @@ EFI_STATUS
 
   @param[in]   This                Pointer to EDKII_REDFISH_ETAG_PROTOCOL instance.
   @param[in]   Uri                 The target Uri which related to ETag.
-  @param[in]   ETag                The ETag to add. If ETag is NULL, the record of correspoonding URI will be removed.
+  @param[in]   ETag                The ETag to add. If ETag is NULL, the record of corresponding URI will be removed.
 
   @retval EFI_SUCCESS              This handler has been stoped successfully.
   @retval Others                   Some error happened.

--- a/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.c
+++ b/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.c
@@ -2,7 +2,7 @@
   Redfish resource config library implementation
 
   (C) Copyright 2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -125,7 +125,7 @@ GetSupportedSchemaVersion (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = RedfishPlatformConfigGetSupportedSchema (NULL, &SupportSchema);
+  Status = RedfishPlatformConfigGetSupportedSchema (&SupportSchema);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/RedfishClientPkg/Library/RedfishAddendumLib/RedfishAddendumLib.c
+++ b/RedfishClientPkg/Library/RedfishAddendumLib/RedfishAddendumLib.c
@@ -129,7 +129,7 @@ RedfishGetAddendumData (
       continue;
     }
 
-    Status = Protocol->ProvisioningCallback (Protocol, &SchemaInfo, JsonValue);
+    Status = Protocol->GetData (Protocol, &SchemaInfo, JsonValue);
     if (!EFI_ERROR (Status)) {
       *JsonWithAddendum = JsonDumpString (JsonValue, EDKII_JSON_COMPACT);
       break;
@@ -232,7 +232,7 @@ RedfishGetOemData (
       continue;
     }
 
-    Status = Protocol->OemCallback (Protocol, &SchemaInfo, JsonValueOem);
+    Status = Protocol->GetOemData (Protocol, &SchemaInfo, JsonValueOem);
     if (!EFI_ERROR (Status)) {
       Status = JsonObjectSetValue (JsonValue, "Oem", JsonValueOem);
       if (!EFI_ERROR (Status)) {

--- a/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.c
+++ b/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.c
@@ -308,7 +308,7 @@ ApplyFeatureSettingsStringType (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s failed: %r\n", __func__, Schema, Version, ConfigureLang, Status));
   } else {
-    if (RedfishValue.Type != REDFISH_VALUE_TYPE_STRING) {
+    if (RedfishValue.Type != RedfishValueTypeString) {
       DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not string type\n", __func__, Schema, Version, ConfigureLang));
       return EFI_DEVICE_ERROR;
     }
@@ -374,7 +374,7 @@ ApplyFeatureSettingsNumericType (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s failed: %r\n", __func__, Schema, Version, ConfigureLang, Status));
   } else {
-    if (RedfishValue.Type != REDFISH_VALUE_TYPE_INTEGER) {
+    if (RedfishValue.Type != RedfishValueTypeInteger) {
       DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not numeric type\n", __func__, Schema, Version, ConfigureLang));
       return EFI_DEVICE_ERROR;
     }
@@ -439,7 +439,7 @@ ApplyFeatureSettingsBooleanType (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s failed: %r\n", __func__, Schema, Version, ConfigureLang, Status));
   } else {
-    if (RedfishValue.Type != REDFISH_VALUE_TYPE_BOOLEAN) {
+    if (RedfishValue.Type != RedfishValueTypeBoolean) {
       DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not boolean type\n", __func__, Schema, Version, ConfigureLang));
       return EFI_DEVICE_ERROR;
     }
@@ -542,11 +542,11 @@ ApplyFeatureSettingsVagueType (
     // Initial property data type and value.
     //
     if (CurrentVagueValuePtr->Value->DataType == RedfishCS_Vague_DataType_String) {
-      PropertyDatatype = REDFISH_VALUE_TYPE_STRING;
+      PropertyDatatype = RedfishValueTypeString;
     } else if (CurrentVagueValuePtr->Value->DataType == RedfishCS_Vague_DataType_Bool) {
-      PropertyDatatype = REDFISH_VALUE_TYPE_BOOLEAN;
+      PropertyDatatype = RedfishValueTypeBoolean;
     } else if (CurrentVagueValuePtr->Value->DataType == RedfishCS_Vague_DataType_Int64) {
-      PropertyDatatype = REDFISH_VALUE_TYPE_INTEGER;
+      PropertyDatatype = RedfishValueTypeInteger;
     } else {
       DEBUG ((DEBUG_ERROR, "%a, %a.%a %s Unsupported Redfish property data type\n", __func__, Schema, Version, ConfigureLang));
       goto ErrorContinue;
@@ -564,7 +564,7 @@ ApplyFeatureSettingsVagueType (
         goto ErrorContinue;
       }
 
-      if (PropertyDatatype == REDFISH_VALUE_TYPE_STRING) {
+      if (PropertyDatatype == RedfishValueTypeString) {
         //
         // This is a string property.
         //
@@ -587,7 +587,7 @@ ApplyFeatureSettingsVagueType (
         } else {
           DEBUG ((DEBUG_MANAGEABILITY, "%a, %a.%a %s value is: %a\n", __func__, Schema, Version, ConfigureKeyLang, RedfishValue.Value.Buffer, Status));
         }
-      } else if (PropertyDatatype == REDFISH_VALUE_TYPE_BOOLEAN) {
+      } else if (PropertyDatatype == RedfishValueTypeBoolean) {
         //
         // This is a boolean property.
         //
@@ -619,7 +619,7 @@ ApplyFeatureSettingsVagueType (
         } else {
           DEBUG ((DEBUG_MANAGEABILITY, "%a, %a.%a %s value is: %a\n", __func__, Schema, Version, ConfigureKeyLang, (RedfishValue.Value.Boolean ? "True" : "False"), Status));
         }
-      } else if (PropertyDatatype == REDFISH_VALUE_TYPE_INTEGER) {
+      } else if (PropertyDatatype == RedfishValueTypeInteger) {
         //
         // This is a integer property.
         //
@@ -695,12 +695,12 @@ FreeArrayTypeRedfishValue (
     return;
   }
 
-  if ((RedfishValue->Type != REDFISH_VALUE_TYPE_INTEGER_ARRAY) && (RedfishValue->Type != REDFISH_VALUE_TYPE_STRING_ARRAY)) {
+  if ((RedfishValue->Type != RedfishValueTypeIntegerArray) && (RedfishValue->Type != RedfishValueTypeStringArray)) {
     return;
   }
 
   switch (RedfishValue->Type) {
-    case REDFISH_VALUE_TYPE_STRING_ARRAY:
+    case RedfishValueTypeStringArray:
       for (Index = 0; Index < RedfishValue->ArrayCount; Index++) {
         FreePool (RedfishValue->Value.StringArray[Index]);
       }
@@ -709,12 +709,12 @@ FreeArrayTypeRedfishValue (
       RedfishValue->Value.StringArray = NULL;
       break;
 
-    case REDFISH_VALUE_TYPE_INTEGER_ARRAY:
+    case RedfishValueTypeIntegerArray:
       FreePool (RedfishValue->Value.IntegerArray);
       RedfishValue->Value.IntegerArray = NULL;
       break;
 
-    case REDFISH_VALUE_TYPE_BOOLEAN_ARRAY:
+    case RedfishValueTypeBooleanArray:
       FreePool (RedfishValue->Value.BooleanArray);
       RedfishValue->Value.BooleanArray = NULL;
       break;
@@ -763,7 +763,7 @@ ApplyFeatureSettingsStringArrayType (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s failed: %r\n", __func__, Schema, Version, ConfigureLang, Status));
   } else {
-    if (RedfishValue.Type != REDFISH_VALUE_TYPE_STRING_ARRAY) {
+    if (RedfishValue.Type != RedfishValueTypeStringArray) {
       DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not string array type\n", __func__, Schema, Version, ConfigureLang));
       return EFI_DEVICE_ERROR;
     }
@@ -866,7 +866,7 @@ ApplyFeatureSettingsNumericArrayType (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s failed: %r\n", __func__, Schema, Version, ConfigureLang, Status));
   } else {
-    if (RedfishValue.Type != REDFISH_VALUE_TYPE_INTEGER_ARRAY) {
+    if (RedfishValue.Type != RedfishValueTypeIntegerArray) {
       DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not string array type\n", __func__, Schema, Version, ConfigureLang));
       return EFI_DEVICE_ERROR;
     }
@@ -964,7 +964,7 @@ ApplyFeatureSettingsBooleanArrayType (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s failed: %r\n", __func__, Schema, Version, ConfigureLang, Status));
   } else {
-    if (RedfishValue.Type != REDFISH_VALUE_TYPE_BOOLEAN_ARRAY) {
+    if (RedfishValue.Type != RedfishValueTypeBooleanArray) {
       DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not string array type\n", __func__, Schema, Version, ConfigureLang));
       return EFI_DEVICE_ERROR;
     }
@@ -2299,7 +2299,7 @@ GetPropertyStringValue (
     return NULL;
   }
 
-  if (RedfishValue.Type != REDFISH_VALUE_TYPE_STRING) {
+  if (RedfishValue.Type != RedfishValueTypeString) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not string type\n", __func__, Schema, Version, ConfigureLang));
     return NULL;
   }
@@ -2357,7 +2357,7 @@ GetPropertyNumericValue (
     return NULL;
   }
 
-  if (RedfishValue.Type != REDFISH_VALUE_TYPE_INTEGER) {
+  if (RedfishValue.Type != RedfishValueTypeInteger) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not numeric type\n", __func__, Schema, Version, ConfigureLang));
     return NULL;
   }
@@ -2419,7 +2419,7 @@ GetPropertyBooleanValue (
     return NULL;
   }
 
-  if (RedfishValue.Type != REDFISH_VALUE_TYPE_BOOLEAN) {
+  if (RedfishValue.Type != RedfishValueTypeBoolean) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not boolean type\n", __func__, Schema, Version, ConfigureLang));
     return NULL;
   }
@@ -2520,7 +2520,7 @@ GetPropertyStringArrayValue (
     return NULL;
   }
 
-  if (RedfishValue.Type != REDFISH_VALUE_TYPE_STRING_ARRAY) {
+  if (RedfishValue.Type != RedfishValueTypeStringArray) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not string array type\n", __func__, Schema, Version, ConfigureLang));
     return NULL;
   }
@@ -2591,7 +2591,7 @@ GetPropertyNumericArrayValue (
     return NULL;
   }
 
-  if (RedfishValue.Type != REDFISH_VALUE_TYPE_INTEGER_ARRAY) {
+  if (RedfishValue.Type != RedfishValueTypeIntegerArray) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not string array type\n", __func__, Schema, Version, ConfigureLang));
     return NULL;
   }
@@ -2662,7 +2662,7 @@ GetPropertyBooleanArrayValue (
     return NULL;
   }
 
-  if (RedfishValue.Type != REDFISH_VALUE_TYPE_BOOLEAN_ARRAY) {
+  if (RedfishValue.Type != RedfishValueTypeBooleanArray) {
     DEBUG ((DEBUG_ERROR, "%a, %a.%a %s value is not string array type\n", __func__, Schema, Version, ConfigureLang));
     return NULL;
   }
@@ -2757,7 +2757,7 @@ NewEmptyPropKeyValueFromRedfishValue (
     return NULL;
   }
 
-  if (RedfishValue->Type == REDFISH_VALUE_TYPE_BOOLEAN) {
+  if (RedfishValue->Type == RedfishValueTypeBoolean) {
     VagueValue->DataType = RedfishCS_Vague_DataType_Bool;
     DataSize             = sizeof (BOOLEAN);
     //
@@ -2766,11 +2766,11 @@ NewEmptyPropKeyValueFromRedfishValue (
     //
     Bool32 = (INT32)RedfishValue->Value.Boolean;
     Data   = (VOID *)&Bool32;
-  } else if (RedfishValue->Type == REDFISH_VALUE_TYPE_INTEGER) {
+  } else if (RedfishValue->Type == RedfishValueTypeInteger) {
     VagueValue->DataType = RedfishCS_Vague_DataType_Int64;
     DataSize             = sizeof (INT64);
     Data                 = (VOID *)&RedfishValue->Value.Integer;
-  } else if (RedfishValue->Type == REDFISH_VALUE_TYPE_STRING) {
+  } else if (RedfishValue->Type == RedfishValueTypeString) {
     VagueValue->DataType = RedfishCS_Vague_DataType_String;
     DataSize             = AsciiStrSize (RedfishValue->Value.Buffer);
     Data                 = (VOID *)RedfishValue->Value.Buffer;

--- a/RedfishClientPkg/RedfishConfigLangMapDxe/RedfishConfigLangMapDxe.c
+++ b/RedfishClientPkg/RedfishConfigLangMapDxe/RedfishConfigLangMapDxe.c
@@ -528,6 +528,7 @@ ON_ERROR:
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishConfigLangMapGet (
   IN  EDKII_REDFISH_CONFIG_LANG_MAP_PROTOCOL  *This,
   IN  REDFISH_CONFIG_LANG_MAP_GET_TYPE        QueryStringType,
@@ -577,6 +578,7 @@ RedfishConfigLangMapGet (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishConfigLangMapSet (
   IN  EDKII_REDFISH_CONFIG_LANG_MAP_PROTOCOL  *This,
   IN  EFI_STRING                              ConfigLang,
@@ -622,6 +624,7 @@ RedfishConfigLangMapSet (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishConfigLangMapFlush (
   IN  EDKII_REDFISH_CONFIG_LANG_MAP_PROTOCOL  *This
   )

--- a/RedfishClientPkg/RedfishETagDxe/RedfishETagDxe.c
+++ b/RedfishClientPkg/RedfishETagDxe/RedfishETagDxe.c
@@ -102,7 +102,7 @@ ON_ERROR:
   @param[in]    Uri   The URI string matching to this ETAG.
   @param[in]    ETag  ETAG string.
 
-  @retval EFI_SUCCESS   ETAG recourd is added.
+  @retval EFI_SUCCESS   ETAG record is added.
   @retval Others        Fail to add ETAG.
 
 **/
@@ -137,7 +137,7 @@ AddETagRecord (
   @param[in]    List    Target ETAG list to be removed.
   @param[in]    Record  Pointer to the instance to be deleted.
 
-  @retval EFI_SUCCESS   ETAG recourd is removed.
+  @retval EFI_SUCCESS   ETAG record is removed.
   @retval Others        Fail to add ETAG.
 
 **/
@@ -357,7 +357,7 @@ SaveETagList (
   }
 
   //
-  // Caculate the total size we need to keep ETag list.
+  // Calculate the total size we need to keep ETag list.
   //
   VarSize = ETagList->TotalSize + 1; // terminator character
   VarData = AllocateZeroPool (VarSize);
@@ -514,6 +514,7 @@ ON_ERROR:
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishETagGet (
   IN  EDKII_REDFISH_ETAG_PROTOCOL  *This,
   IN  CHAR8                        *Uri,
@@ -546,13 +547,14 @@ RedfishETagGet (
 
   @param[in]   This                Pointer to EDKII_REDFISH_ETAG_PROTOCOL instance.
   @param[in]   Uri                 The target Uri which related to ETag.
-  @param[in]   ETag                The ETag to add. If ETag is NULL, the record of correspoonding URI will be removed.
+  @param[in]   ETag                The ETag to add. If ETag is NULL, the record of corresponding URI will be removed.
 
   @retval EFI_SUCCESS              This handler has been stoped successfully.
   @retval Others                   Some error happened.
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishETagSet (
   IN  EDKII_REDFISH_ETAG_PROTOCOL  *This,
   IN  CHAR8                        *Uri,
@@ -579,7 +581,7 @@ RedfishETagSet (
   }
 
   //
-  // When ETag is NULL, it means that we want to remov this record.
+  // When ETag is NULL, it means that we want to remove this record.
   //
   if (ETag == NULL) {
     return Status;
@@ -598,6 +600,7 @@ RedfishETagSet (
 
 **/
 EFI_STATUS
+EFIAPI
 RedfishETagFlush (
   IN  EDKII_REDFISH_ETAG_PROTOCOL  *This
   )


### PR DESCRIPTION
V2:
Instead of modifying ConverterLib, use build option in INF file to fix build error

V1:
Fix RedfishClientPkg build errors and typos. The compiler toolchain is GCC5.

Signed-off-by: Nickle Wang <[nicklew@nvidia.com](mailto:nicklew@nvidia.com)>
Cc: Abner Chang <[abner.chang@amd.com](mailto:abner.chang@amd.com)>
Cc: Igor Kulchytskyy <[igork@ami.com](mailto:igork@ami.com)>
Reviewed-by: Abner Chang <abner.chang@amd.com>