### PR TITLE
Remove reference to BaseSortLib library

### DIFF
--- a/RedfishClientPkg/RedfishClientPkg.dsc
+++ b/RedfishClientPkg/RedfishClientPkg.dsc
@@ -36,7 +36,6 @@
   JsonLib|RedfishPkg/Library/JsonLib/JsonLib.inf
   Ucs2Utf8Lib|RedfishPkg/Library/BaseUcs2Utf8Lib/BaseUcs2Utf8Lib.inf
   RedfishCrtLib|RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf
-  BaseSortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
   HiiLib|MdeModulePkg/Library/UefiHiiLib/UefiHiiLib.inf
   UefiHiiServicesLib|MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.inf
   UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf


### PR DESCRIPTION
There are two problems with BaseSortLib reference: 1 BaseSortLib is the library instance name not the class name. 2 UefiSortLib instance from MdeModulePkg is also referenced below.

Let's use only one reference to SortLib.
While Redfish Client uses only quick sort for char* elements, UefiSortLib is preferred as it allows to sort DevicePath instances and wide strings.

Signed-off-by: Mike Maslenkin <mike.maslenkin@gmail.com>
Cc: Abner Chang <abner.chang@amd.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>