### PR TITLE
RedfishClientPkg: rename RedfishResourceIdentifyLibComuterSystem

### DIFF
--- a/RedfishClientPkg/Library/RedfishResourceIdentifyLibComputerSystem/v1_5_0/RedfishResourceIdentifyLibComputerSystem.c
+++ b/RedfishClientPkg/Library/RedfishResourceIdentifyLibComputerSystem/v1_5_0/RedfishResourceIdentifyLibComputerSystem.c
@@ -144,7 +144,7 @@ RestJasonStructureProtocolIsReady (
 **/
 EFI_STATUS
 EFIAPI
-RedfishResourceIdentifyComuterSystemConstructor (
+RedfishResourceIdentifyComputerSystemConstructor (
   IN EFI_HANDLE        ImageHandle,
   IN EFI_SYSTEM_TABLE  *SystemTable
   )

--- a/RedfishClientPkg/Library/RedfishResourceIdentifyLibComputerSystem/v1_5_0/RedfishResourceIdentifyLibComputerSystem.inf
+++ b/RedfishClientPkg/Library/RedfishResourceIdentifyLibComputerSystem/v1_5_0/RedfishResourceIdentifyLibComputerSystem.inf
@@ -8,19 +8,19 @@
 
 [Defines]
   INF_VERSION                    = 0x00010006
-  BASE_NAME                      = RedfishResourceIdentifyLibComuterSystem
+  BASE_NAME                      = RedfishResourceIdentifyLibComputerSystem
   FILE_GUID                      = 2AEE2C80-126A-44A6-877E-642F20510D13
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = RedfishResourceIdentifyLib| DXE_DRIVER
-  CONSTRUCTOR                    = RedfishResourceIdentifyComuterSystemConstructor
+  CONSTRUCTOR                    = RedfishResourceIdentifyComputerSystemConstructor
 
 #
 #  VALID_ARCHITECTURES           = IA32 X64 EBC
 #
 
 [Sources]
-  RedfishResourceIdentifyLibComuterSystem.c
+  RedfishResourceIdentifyLibComputerSystem.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/RedfishClientPkg/RedfishClientComponents.dsc.inc
+++ b/RedfishClientPkg/RedfishClientComponents.dsc.inc
@@ -28,7 +28,7 @@
   RedfishClientPkg/Features/MemoryCollectionDxe/MemoryCollectionDxe.inf
   RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.inf {
     <LibraryClasses>
-      RedfishResourceIdentifyLib|RedfishClientPkg/Library/RedfishResourceIdentifyLibComuterSystem/v1_5_0/RedfishResourceIdentifyLibComuterSystem.inf
+      RedfishResourceIdentifyLib|RedfishClientPkg/Library/RedfishResourceIdentifyLibComputerSystem/v1_5_0/RedfishResourceIdentifyLibComputerSystem.inf
   }
   RedfishClientPkg/Features/ComputerSystemCollectionDxe/ComputerSystemCollectionDxe.inf
   RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.inf


### PR DESCRIPTION
This patch fixes misprint in name of a directory and its files. The name of these files should be RedfishResourceIdentifyLibComputerSystem as well as implemented library instance.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Nickle Wang <nicklew@nvidia.com>
Cc: Igor Kulchytskyy <igork@ami.com>