### PR TITLE
RedfishClientPkg/RedfishFeatureCoreDxe: fix Redfish event issue.

### DIFF
--- a/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.c
+++ b/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.c
@@ -273,6 +273,13 @@ RedfishFeatureDriverStartup (
   }
 
   //
+  // Lower the TPL to TPL_APPLICATION so that
+  // Redfish event and report status code can be
+  // triggered
+  //
+  gBS->RestoreTPL (TPL_APPLICATION);
+
+  //
   // Reset PcdRedfishSystemRebootRequired flag
   //
   PcdSetBoolS (PcdRedfishSystemRebootRequired, FALSE);
@@ -321,6 +328,11 @@ RedfishFeatureDriverStartup (
     gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
     CpuDeadLoop ();
   }
+
+  //
+  // Restore to the TPL where this callback handler is called.
+  //
+  gBS->RaiseTPL (REDFISH_FEATURE_CORE_TPL);
 }
 
 /**
@@ -670,7 +682,7 @@ RedfishFeatureCoreEntryPoint (
 
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
-                  TPL_CALLBACK,
+                  REDFISH_FEATURE_CORE_TPL,
                   RedfishFeatureDriverStartup,
                   (CONST VOID *)&mFeatureDriverStartupContext,
                   EventGuid,

--- a/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.h
+++ b/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.h
@@ -33,6 +33,7 @@
 #define NodeIsCollectionLeftBracket   L'{'
 #define NodeIsCollectionRightBracket  L'}'
 #define NodeIsCollectionSymbol        L"/{}"
+#define REDFISH_FEATURE_CORE_TPL      TPL_CALLBACK
 
 typedef struct _REDFISH_FEATURE_INTERNAL_DATA REDFISH_FEATURE_INTERNAL_DATA;
 struct _REDFISH_FEATURE_INTERNAL_DATA {


### PR DESCRIPTION
RedfishFeatureDriverStartup is callback function at TPL_CALLBACK level. In this function, Redfish events are signaled. However, Redfish events are created in TPL_CALLBACK level too. As the result, Redfish events cannot be invoked in desired sequence. Decrease the TPL to TPL_APPLICATION level inside RedfishFeatureDriverStartup and restore it to TPL_CALLBACK level before leaving this function. Now, Redfish events are called in correct sequence.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nick Ramirez <nramirez@nvidia.com>