### PR TITLE
Use POST for provisioning Bios attributes

### DIFF
--- a/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.c
+++ b/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.c
@@ -562,7 +562,7 @@ EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL  mRedfishConfigHandler = {
 **/
 VOID
 EFIAPI
-EfiRestJasonStructureProtocolIsReady (
+EfiRestJsonStructureProtocolIsReady (
   IN  EFI_EVENT  Event,
   IN  VOID       *Context
   )
@@ -829,7 +829,7 @@ RedfishResourceEntryPoint (
   EfiCreateProtocolNotifyEvent (
     &gEfiRestJsonStructureProtocolGuid,
     TPL_CALLBACK,
-    EfiRestJasonStructureProtocolIsReady,
+    EfiRestJsonStructureProtocolIsReady,
     NULL,
     &Registration
     );

--- a/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.c
+++ b/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.c
@@ -1856,7 +1856,8 @@ GetEtagAndLocation (
   }
 
   if (Location != NULL) {
-    *Location = NULL;
+    *Location     = NULL;
+    AsciiLocation = NULL;
 
     if (*(Response->StatusCode) == HTTP_STATUS_200_OK) {
       Header = HttpFindHeader (Response->HeaderCount, Response->Headers, HTTP_HEADER_LOCATION);

--- a/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.c
+++ b/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.c
@@ -3118,7 +3118,9 @@ LeaveFunction:
     FreePool (ConfigureLangBuffer);
   }
 
-  FreePool (ConfigureLangList);
+  if (ConfigureLangList != NULL) {
+    FreePool (ConfigureLangList);
+  }
 
   *NumberOfValues = (UINT32)ListCount;
   return FirstEmptyPropKeyValueList;


### PR DESCRIPTION
This patch set contains small fixes and the one major change related to Bios resources provisioning.