### PR TITLE
RedfishClientPkg: introduce Redfish HTTP cache library

### DIFF
--- a/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.c
+++ b/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.c
@@ -2,7 +2,7 @@
   Redfish feature driver implementation - Bios
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+  Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -55,7 +55,8 @@ RedfishResourceProvisioningResource (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;
@@ -77,6 +78,7 @@ RedfishResourceProvisioningResource (
       Response.Headers,
       Response.Payload
       );
+    RedfishHttpResetResource (Uri);
     Private->Payload = NULL;
   }
 
@@ -103,13 +105,10 @@ RedfishResourceConsumeResource (
   REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
   EFI_STATUS                       Status;
   REDFISH_RESPONSE                 Response;
+  EFI_STRING                       PendingSettingUri;
+  REDFISH_RESPONSE                 PendingSettingResponse;
   REDFISH_RESPONSE                 *ExpectedResponse;
-  REDFISH_RESPONSE                 RedfishSettingsResponse;
   CHAR8                            *Etag;
-  UINTN                            Index;
-  EDKII_JSON_VALUE                 JsonValue;
-  EFI_STRING                       RedfishSettingsUri;
-  CONST CHAR8                      *RedfishSettingsUriKeys[] = { "@Redfish.Settings", "SettingsObject", "@odata.id" };
 
   if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
     return EFI_INVALID_PARAMETER;
@@ -121,45 +120,32 @@ RedfishResourceConsumeResource (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;
   }
 
-  ZeroMem (&RedfishSettingsResponse, sizeof (REDFISH_RESPONSE));
-
-  ExpectedResponse   = &Response;
-  RedfishSettingsUri = NULL;
-  JsonValue          = RedfishJsonInPayload (Response.Payload);
-
   //
-  // Seeking RedfishSettings URI link.
+  // Check and see if "@Redfish.Settings" exist or not.
   //
-  for (Index = 0; Index < sizeof (RedfishSettingsUriKeys) / sizeof (*RedfishSettingsUriKeys); Index++) {
-    if (JsonValue == NULL) {
-      break;
-    }
-
-    JsonValue = JsonObjectGetValue (JsonValueGetObject (JsonValue), RedfishSettingsUriKeys[Index]);
+  ZeroMem (&PendingSettingResponse, sizeof (REDFISH_RESPONSE));
+  Status = GetPendingSettings (
+             Private->RedfishService,
+             Response.Payload,
+             &PendingSettingResponse,
+             &PendingSettingUri
+             );
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((REDFISH_DEBUG_TRACE, "%a: @Redfish.Settings found: %s\n", __func__, PendingSettingUri));
+    Private->Uri     = PendingSettingUri;
+    ExpectedResponse = &PendingSettingResponse;
+  } else {
+    Private->Uri     = Uri;
+    ExpectedResponse = &Response;
   }
 
-  if (JsonValue != NULL) {
-    //
-    // Verify RedfishSettings URI link is valid to retrieve resource or not.
-    //
-    RedfishSettingsUri = JsonValueGetUnicodeString (JsonValue);
-
-    Status = GetResourceByUri (Private->RedfishService, RedfishSettingsUri, &RedfishSettingsResponse);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a, @Redfish.Settings exists, get resource from: %s failed\n", __FUNCTION__, RedfishSettingsUri));
-    } else {
-      Uri              = RedfishSettingsUri;
-      ExpectedResponse = &RedfishSettingsResponse;
-    }
-  }
-
-  Private->Uri     = Uri;
   Private->Payload = ExpectedResponse->Payload;
   ASSERT (Private->Payload != NULL);
 
@@ -202,12 +188,12 @@ RedfishResourceConsumeResource (
         );
     }
 
-    if (RedfishSettingsResponse.Payload != NULL) {
+    if (PendingSettingResponse.Payload != NULL) {
       RedfishFreeResponse (
-        RedfishSettingsResponse.StatusCode,
-        RedfishSettingsResponse.HeaderCount,
-        RedfishSettingsResponse.Headers,
-        RedfishSettingsResponse.Payload
+        PendingSettingResponse.StatusCode,
+        PendingSettingResponse.HeaderCount,
+        PendingSettingResponse.Headers,
+        PendingSettingResponse.Payload
         );
     }
 
@@ -289,7 +275,8 @@ RedfishResourceUpdate (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;
@@ -317,6 +304,7 @@ RedfishResourceUpdate (
       Response.Headers,
       Response.Payload
       );
+    RedfishHttpResetResource (Uri);
     Private->Payload = NULL;
   }
 
@@ -359,7 +347,8 @@ RedfishResourceCheck (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;
@@ -430,7 +419,8 @@ RedfishResourceIdentify (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;
@@ -695,7 +685,7 @@ RedfishExternalResourceResourceFeatureCallback (
   Private->InformationExchange = InformationExchange;
 
   //
-  // Find Redfish version on BMC
+  // Find Redfish version on Redfish service.
   //
   Private->RedfishVersion = RedfishGetVersion (RedfishService);
 

--- a/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.inf
+++ b/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.inf
@@ -1,7 +1,7 @@
 ## @file
 #
 #  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
-#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -39,6 +39,7 @@
   UefiLib
   UefiDriverEntryPoint
   RedfishAddendumLib
+  RedfishHttpCacheLib
 
 [Protocols]
   gEdkIIRedfishConfigHandlerProtocolGuid          ## PRODUCED

--- a/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.c
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.c
@@ -2,7 +2,7 @@
   Redfish feature driver implementation - ComputerSystem
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -49,7 +49,8 @@ RedfishResourceProvisioningResource (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;
@@ -71,6 +72,7 @@ RedfishResourceProvisioningResource (
       Response.Headers,
       Response.Payload
       );
+    RedfishHttpResetResource (Uri);
     Private->Payload = NULL;
   }
 
@@ -97,6 +99,9 @@ RedfishResourceConsumeResource (
   REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
   EFI_STATUS                       Status;
   REDFISH_RESPONSE                 Response;
+  EFI_STRING                       PendingSettingUri;
+  REDFISH_RESPONSE                 PendingSettingResponse;
+  REDFISH_RESPONSE                 *ExpectedResponse;
   CHAR8                            *Etag;
 
   if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
@@ -109,14 +114,33 @@ RedfishResourceConsumeResource (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;
   }
 
-  Private->Uri     = Uri;
-  Private->Payload = Response.Payload;
+  //
+  // Check and see if "@Redfish.Settings" exist or not.
+  //
+  ZeroMem (&PendingSettingResponse, sizeof (REDFISH_RESPONSE));
+  Status = GetPendingSettings (
+             Private->RedfishService,
+             Response.Payload,
+             &PendingSettingResponse,
+             &PendingSettingUri
+             );
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((REDFISH_DEBUG_TRACE, "%a: @Redfish.Settings found: %s\n", __func__, PendingSettingUri));
+    Private->Uri     = PendingSettingUri;
+    ExpectedResponse = &PendingSettingResponse;
+  } else {
+    Private->Uri     = Uri;
+    ExpectedResponse = &Response;
+  }
+
+  Private->Payload = ExpectedResponse->Payload;
   ASSERT (Private->Payload != NULL);
 
   Private->Json = JsonDumpString (RedfishJsonInPayload (Private->Payload), EDKII_JSON_COMPACT);
@@ -126,7 +150,7 @@ RedfishResourceConsumeResource (
   // Find etag in HTTP response header
   //
   Etag   = NULL;
-  Status = GetEtagAndLocation (&Response, &Etag, NULL);
+  Status = GetEtagAndLocation (ExpectedResponse, &Etag, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, failed to get ETag from HTTP header\n", __func__));
   }
@@ -149,12 +173,24 @@ RedfishResourceConsumeResource (
   // Release resource
   //
   if (Private->Payload != NULL) {
-    RedfishFreeResponse (
-      Response.StatusCode,
-      Response.HeaderCount,
-      Response.Headers,
-      Response.Payload
-      );
+    if (Response.Payload != NULL) {
+      RedfishFreeResponse (
+        Response.StatusCode,
+        Response.HeaderCount,
+        Response.Headers,
+        Response.Payload
+        );
+    }
+
+    if (PendingSettingResponse.Payload != NULL) {
+      RedfishFreeResponse (
+        PendingSettingResponse.StatusCode,
+        PendingSettingResponse.HeaderCount,
+        PendingSettingResponse.Headers,
+        PendingSettingResponse.Payload
+        );
+    }
+
     Private->Payload = NULL;
   }
 
@@ -233,7 +269,8 @@ RedfishResourceUpdate (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;
@@ -261,6 +298,7 @@ RedfishResourceUpdate (
       Response.Headers,
       Response.Payload
       );
+    RedfishHttpResetResource (Uri);
     Private->Payload = NULL;
   }
 
@@ -303,7 +341,8 @@ RedfishResourceCheck (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;
@@ -374,7 +413,8 @@ RedfishResourceIdentify (
     return EFI_NOT_READY;
   }
 
-  Status = GetResourceByUri (Private->RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
     return Status;

--- a/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.inf
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.inf
@@ -1,6 +1,7 @@
 ## @file
 #
 #  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -36,7 +37,7 @@
   RedfishResourceIdentifyLib
   UefiLib
   UefiDriverEntryPoint
-
+  RedfishHttpCacheLib
 
 [Protocols]
   gEdkIIRedfishConfigHandlerProtocolGuid          ## PRODUCED

--- a/RedfishClientPkg/Features/ComputerSystemCollectionDxe/ComputerSystemCollectionDxe.c
+++ b/RedfishClientPkg/Features/ComputerSystemCollectionDxe/ComputerSystemCollectionDxe.c
@@ -3,7 +3,7 @@
   Redfish feature driver implementation - ComputerSystemCollection
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -256,17 +256,17 @@ ReleaseCollectionResource (
   //
   // Release resource
   //
-  if (Private->RedResponse.Payload != NULL) {
+  if (Private->Response.Payload != NULL) {
     RedfishFreeResponse (
-      Private->RedResponse.StatusCode,
-      Private->RedResponse.HeaderCount,
-      Private->RedResponse.Headers,
-      Private->RedResponse.Payload
+      Private->Response.StatusCode,
+      Private->Response.HeaderCount,
+      Private->Response.Headers,
+      Private->Response.Payload
       );
-    Private->RedResponse.StatusCode  = NULL;
-    Private->RedResponse.HeaderCount = 0;
-    Private->RedResponse.Headers     = NULL;
-    Private->RedResponse.Payload     = NULL;
+    Private->Response.StatusCode  = NULL;
+    Private->Response.HeaderCount = 0;
+    Private->Response.Headers     = NULL;
+    Private->Response.Payload     = NULL;
   }
 
   if (Private->CollectionJson != NULL) {
@@ -298,13 +298,13 @@ CollectionHandler (
   //
   // Query collection from Redfish service.
   //
-  Status = GetResourceByUri (Private->RedfishService, Private->CollectionUri, &Private->RedResponse);
+  Status = RedfishHttpGetResource (Private->RedfishService, Private->CollectionUri, &Private->Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: unable to get resource from: %s :%r\n", __func__, Private->CollectionUri, Status));
     goto ON_RELEASE;
   }
 
-  Private->CollectionPayload = Private->RedResponse.Payload;
+  Private->CollectionPayload = Private->Response.Payload;
   ASSERT (Private->CollectionPayload != NULL);
 
   Private->CollectionJson = JsonDumpString (RedfishJsonInPayload (Private->CollectionPayload), EDKII_JSON_COMPACT);
@@ -370,7 +370,7 @@ RedfishCollectionFeatureCallback (
   Private->InformationExchange = InformationExchange;
 
   //
-  // Find Redfish version on BMC
+  // Find Redfish version on Redfish service.
   //
   Private->RedfishVersion = RedfishGetVersion (RedfishService);
 

--- a/RedfishClientPkg/Features/ComputerSystemCollectionDxe/ComputerSystemCollectionDxe.inf
+++ b/RedfishClientPkg/Features/ComputerSystemCollectionDxe/ComputerSystemCollectionDxe.inf
@@ -3,6 +3,7 @@
 #  Redfish ComputerSystemCollection collection driver.
 #
 #  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -40,6 +41,7 @@
   UefiBootServicesTableLib
   EdkIIRedfishResourceConfigLib
   RedfishVersionLib
+  RedfishHttpCacheLib
 
 [Protocols]
   gEdkIIRedfishConfigHandlerProtocolGuid    ## CONSUMED

--- a/RedfishClientPkg/Features/Memory/V1_7_1/Dxe/MemoryDxe.inf
+++ b/RedfishClientPkg/Features/Memory/V1_7_1/Dxe/MemoryDxe.inf
@@ -1,6 +1,7 @@
 ## @file
 #
 #  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -36,7 +37,7 @@
   RedfishResourceIdentifyLib
   UefiLib
   UefiDriverEntryPoint
-
+  RedfishHttpCacheLib
 
 [Protocols]
   gEdkIIRedfishConfigHandlerProtocolGuid          ## PRODUCED

--- a/RedfishClientPkg/Features/MemoryCollectionDxe/MemoryCollectionDxe.c
+++ b/RedfishClientPkg/Features/MemoryCollectionDxe/MemoryCollectionDxe.c
@@ -3,7 +3,7 @@
   Redfish feature driver implementation - MemoryCollection
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -247,17 +247,17 @@ ReleaseCollectionResource (
   //
   // Release resource
   //
-  if (Private->RedResponse.Payload != NULL) {
+  if (Private->Response.Payload != NULL) {
     RedfishFreeResponse (
-      Private->RedResponse.StatusCode,
-      Private->RedResponse.HeaderCount,
-      Private->RedResponse.Headers,
-      Private->RedResponse.Payload
+      Private->Response.StatusCode,
+      Private->Response.HeaderCount,
+      Private->Response.Headers,
+      Private->Response.Payload
       );
-    Private->RedResponse.StatusCode  = NULL;
-    Private->RedResponse.HeaderCount = 0;
-    Private->RedResponse.Headers     = NULL;
-    Private->RedResponse.Payload     = NULL;
+    Private->Response.StatusCode  = NULL;
+    Private->Response.HeaderCount = 0;
+    Private->Response.Headers     = NULL;
+    Private->Response.Payload     = NULL;
   }
 
   if (Private->CollectionJson != NULL) {
@@ -289,13 +289,13 @@ CollectionHandler (
   //
   // Query collection from Redfish service.
   //
-  Status = GetResourceByUri (Private->RedfishService, Private->CollectionUri, &Private->RedResponse);
+  Status = RedfishHttpGetResource (Private->RedfishService, Private->CollectionUri, &Private->Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, unable to get resource from: %s :%r\n", __func__, Private->CollectionUri, Status));
     goto ON_RELEASE;
   }
 
-  Private->CollectionPayload = Private->RedResponse.Payload;
+  Private->CollectionPayload = Private->Response.Payload;
   ASSERT (Private->CollectionPayload != NULL);
 
   Private->CollectionJson = JsonDumpString (RedfishJsonInPayload (Private->CollectionPayload), EDKII_JSON_COMPACT);
@@ -360,7 +360,7 @@ RedfishCollectionFeatureCallback (
   Private->InformationExchange = InformationExchange;
 
   //
-  // Find Redfish version on BMC
+  // Find Redfish version on Redfish service.
   //
   Private->RedfishVersion = RedfishGetVersion (RedfishService);
 

--- a/RedfishClientPkg/Features/MemoryCollectionDxe/MemoryCollectionDxe.inf
+++ b/RedfishClientPkg/Features/MemoryCollectionDxe/MemoryCollectionDxe.inf
@@ -3,6 +3,7 @@
 #  Redfish MemoryCollection collection driver.
 #
 #  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -40,6 +41,7 @@
   UefiBootServicesTableLib
   EdkIIRedfishResourceConfigLib
   RedfishVersionLib
+  RedfishHttpCacheLib
 
 [Protocols]
   gEdkIIRedfishConfigHandlerProtocolGuid    ## CONSUMED

--- a/RedfishClientPkg/Include/Library/RedfishFeatureUtilityLib.h
+++ b/RedfishClientPkg/Include/Library/RedfishFeatureUtilityLib.h
@@ -2,7 +2,7 @@
   This file defines the Redfish Feature Utility Library interface.
 
   (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -17,25 +17,6 @@
 #include <RedfishJsonStructure/RedfishCsCommon.h>
 
 #define REDFISH_ENABLE_SYSTEM_REBOOT()  PcdSetBoolS(PcdRedfishSystemRebootRequired, TRUE)
-
-/**
-
-  Read redfish resource by given resource URI.
-
-  @param[in]  Service       Redfish service instance to make query.
-  @param[in]  ResourceUri   Target resource URI.
-  @param[out] Response      HTTP response from redfish service.
-
-  @retval     EFI_SUCCESS     Resrouce is returned successfully.
-  @retval     Others          Errors occur.
-
-**/
-EFI_STATUS
-GetResourceByUri (
-  IN  REDFISH_SERVICE   *Service,
-  IN  EFI_STRING        ResourceUri,
-  OUT REDFISH_RESPONSE  *Response
-  );
 
 /**
 

--- a/RedfishClientPkg/Include/Library/RedfishHttpCacheLib.h
+++ b/RedfishClientPkg/Include/Library/RedfishHttpCacheLib.h
@@ -1,0 +1,59 @@
+/** @file
+  This file defines the Redfish HTTP cache library interface.
+
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef REDFISH_HTTP_CACHE_LIB_H_
+#define REDFISH_HTTP_CACHE_LIB_H_
+
+#include <Uefi.h>
+#include <Library/RedfishLib.h>
+
+/**
+  Get redfish resource from given resource URI with cache mechanism
+  supported. It's caller's responsibility to Response by calling
+  RedfishFreeResponse ().
+
+  @param[in]  Service       Redfish service instance to make query.
+  @param[in]  Uri           Target resource URI.
+  @param[out] Response      HTTP response from redfish service.
+  @param[in]  UseCache      If it is TRUE, this function will search for
+                            cache first. If it is FALSE, this function
+                            will query Redfish URI directly.
+
+  @retval     EFI_SUCCESS     Resrouce is returned successfully.
+  @retval     Others          Errors occur.
+
+**/
+EFI_STATUS
+RedfishHttpGetResource (
+  IN  REDFISH_SERVICE   Service,
+  IN  EFI_STRING        Uri,
+  OUT REDFISH_RESPONSE  *Response,
+  IN  BOOLEAN           UseCache
+  );
+
+/**
+  Reset the cached data specified by given URI. When response data
+  returned by RedfishHttpResetResource() is modified, the response
+  data can not be used by other caller. Application calls this
+  function to make this data to be stale data and
+  RedfishHttpResetResource() will get latest data from remote server
+  again.
+
+  @param[in]  Uri           Target resource URI.
+
+  @retval     EFI_SUCCESS     Resrouce is reset successfully.
+  @retval     Others          Errors occur.
+
+**/
+EFI_STATUS
+RedfishHttpResetResource (
+  IN  EFI_STRING  Uri
+  );
+
+#endif

--- a/RedfishClientPkg/Include/Library/RedfishVersionLib.h
+++ b/RedfishClientPkg/Include/Library/RedfishVersionLib.h
@@ -2,6 +2,7 @@
   This file defines the Redfish version Library interface.
 
   (C) Copyright 2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -11,8 +12,8 @@
 #define REDFISH_VERSION_LIB_H_
 
 /**
-  Query HTTP request to BMC with given redfish service and return redfish
-  version information. If there is troulbe to get Redfish version on BMC,
+  Query HTTP request to redfish service and return redfish
+  version information. If there is trouble to get Redfish version on service,
   The value of PcdDefaultRedfishVersion is returned.
 
   It's call responsibility to release returned buffer.

--- a/RedfishClientPkg/Include/RedfishCollectionCommon.h
+++ b/RedfishClientPkg/Include/RedfishCollectionCommon.h
@@ -2,6 +2,7 @@
   Redfish feature driver collection common header file.
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -26,6 +27,7 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/EdkIIRedfishResourceConfigLib.h>
 #include <Library/RedfishVersionLib.h>
+#include <Library/RedfishHttpCacheLib.h>
 
 //
 // Protocols
@@ -46,7 +48,7 @@ typedef struct _REDFISH_COLLECTION_PRIVATE {
   EFI_STRING                               CollectionUri;
   CHAR8                                    *CollectionJson;
   REDFISH_PAYLOAD                          CollectionPayload;
-  REDFISH_RESPONSE                         RedResponse;
+  REDFISH_RESPONSE                         Response;
   EFI_STRING                               RedfishVersion;
 } REDFISH_COLLECTION_PRIVATE;
 

--- a/RedfishClientPkg/Include/RedfishResourceCommon.h
+++ b/RedfishClientPkg/Include/RedfishResourceCommon.h
@@ -2,7 +2,7 @@
   Redfish feature driver common header file.
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -32,6 +32,7 @@
 #include <Library/RedfishResourceIdentifyLib.h>
 #include <Library/EdkIIRedfishResourceConfigLib.h>
 #include <Library/RedfishAddendumLib.h>
+#include <Library/RedfishHttpCacheLib.h>
 
 //
 // Protocols

--- a/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.c
+++ b/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.c
@@ -2,7 +2,7 @@
   Redfish resource config library implementation
 
   (C) Copyright 2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -16,6 +16,7 @@
 #include <Library/EdkIIRedfishResourceConfigLib.h>
 #include <Library/RedfishFeatureUtilityLib.h>
 #include <Library/RedfishPlatformConfigLib.h>
+#include <Library/RedfishHttpCacheLib.h>
 
 EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL           *mRedfishResourceConfigProtocol = NULL;
 EFI_HANDLE                                       mCachedHandle;
@@ -56,7 +57,8 @@ GetRedfishSchemaInfo (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = GetResourceByUri (RedfishService, Uri, &Response);
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (RedfishService, Uri, &Response, TRUE);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, failed to get resource from %s: %r", __func__, Uri, Status));
     return Status;

--- a/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.inf
+++ b/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.inf
@@ -1,6 +1,7 @@
 ## @file
 #
 #  (C) Copyright 2022 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -38,6 +39,7 @@
   MemoryAllocationLib
   RedfishFeatureUtilityLib
   RedfishPlatformConfigLib
+  RedfishHttpCacheLib
 
 [Protocols]
   gEdkIIRedfishResourceConfigProtocolGuid   ## CONSUMES ##

--- a/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityInternal.h
+++ b/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityInternal.h
@@ -2,7 +2,7 @@
   Common header file for RedfishFeatureUtilityLib driver.
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -30,6 +30,7 @@
 #include <Library/PrintLib.h>
 #include <Library/HttpLib.h>
 #include <Library/RedfishDebugLib.h>
+#include <Library/RedfishHttpCacheLib.h>
 
 #include <Guid/VariableFormat.h>
 

--- a/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.inf
+++ b/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.inf
@@ -2,7 +2,7 @@
 #  INF for Redfish feature utility library.
 #
 #  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
-#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -46,6 +46,7 @@
   PrintLib
   HttpLib
   RedfishDebugLib
+  RedfishHttpCacheLib
 
 [Protocols]
   gEdkIIRedfishETagProtocolGuid           ## CONSUMED ##

--- a/RedfishClientPkg/Library/RedfishHttpCacheLib/RedfishHttpCacheLib.c
+++ b/RedfishClientPkg/Library/RedfishHttpCacheLib/RedfishHttpCacheLib.c
@@ -1,0 +1,774 @@
+/** @file
+  Redfish HTTP cache library helps Redfish application to get Redfish resource
+  from Redfish service with cache mechanism enabled.
+
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "RedfishHttpCacheLibInternal.h"
+
+REDFISH_HTTP_CACHE_PRIVATE  *mRedfishHttpCachePrivate = NULL;
+
+/**
+  This function copy the data in SrcResponse to DstResponse.
+
+  @param[in]  SrcResponse      Source Response to copy.
+  @param[out] DstResponse      Destination Response.
+
+  @retval     EFI_SUCCESS      Response is copied successfully.
+  @retval     Others           Error occurs.
+
+**/
+EFI_STATUS
+CopyRedfishResponse (
+  IN  REDFISH_RESPONSE  *SrcResponse,
+  OUT REDFISH_RESPONSE  *DstResponse
+  )
+{
+  EDKII_JSON_VALUE  JsonValue;
+  REDFISH_SERVICE   Service;
+  UINTN             Index;
+
+  if ((SrcResponse == NULL) || (DstResponse == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (SrcResponse == DstResponse) {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Status code
+  //
+  if (SrcResponse->StatusCode != NULL) {
+    DstResponse->StatusCode = AllocateCopyPool (sizeof (EFI_HTTP_STATUS_CODE), SrcResponse->StatusCode);
+    if (DstResponse->StatusCode == NULL) {
+      goto ON_ERROR;
+    }
+  }
+
+  //
+  // Header
+  //
+  if ((SrcResponse->HeaderCount > 0) && (SrcResponse->Headers != NULL)) {
+    DstResponse->HeaderCount = 0;
+    DstResponse->Headers     = AllocateZeroPool (sizeof (EFI_HTTP_HEADER) * SrcResponse->HeaderCount);
+    if (DstResponse->Headers == NULL) {
+      goto ON_ERROR;
+    }
+
+    for (Index = 0; Index < SrcResponse->HeaderCount; Index++) {
+      DstResponse->Headers[Index].FieldName = AllocateCopyPool (AsciiStrSize (SrcResponse->Headers[Index].FieldName), SrcResponse->Headers[Index].FieldName);
+      if (DstResponse->Headers[Index].FieldName == NULL) {
+        goto ON_ERROR;
+      }
+
+      DstResponse->Headers[Index].FieldValue = AllocateCopyPool (AsciiStrSize (SrcResponse->Headers[Index].FieldValue), SrcResponse->Headers[Index].FieldValue);
+      if (DstResponse->Headers[Index].FieldValue == NULL) {
+        goto ON_ERROR;
+      }
+
+      DstResponse->HeaderCount += 1;
+    }
+  }
+
+  //
+  // Payload
+  //
+  if (SrcResponse->Payload != NULL) {
+    Service              = RedfishServiceInPayload (SrcResponse->Payload);
+    JsonValue            = RedfishJsonInPayload (SrcResponse->Payload);
+    DstResponse->Payload = RedfishCreatePayload (JsonValue, Service);
+    if (DstResponse->Payload  == NULL) {
+      goto ON_ERROR;
+    }
+  }
+
+  return EFI_SUCCESS;
+
+ON_ERROR:
+
+  RedfishFreeResponse (
+    DstResponse->StatusCode,
+    DstResponse->HeaderCount,
+    DstResponse->Headers,
+    DstResponse->Payload
+    );
+
+  return EFI_OUT_OF_RESOURCES;
+}
+
+/**
+  This function clone input response and return to caller
+
+  @param[in]  Response      Response to clone.
+
+  @retval     REDFISH_RESPONSE *  Response is cloned.
+  @retval     NULL                Errors occur.
+
+**/
+REDFISH_RESPONSE *
+CloneRedfishResponse (
+  IN REDFISH_RESPONSE  *Response
+  )
+{
+  EFI_STATUS        Status;
+  REDFISH_RESPONSE  *NewResponse;
+
+  if (Response == NULL) {
+    return NULL;
+  }
+
+  NewResponse = AllocateZeroPool (sizeof (REDFISH_RESPONSE));
+  if (NewResponse == NULL) {
+    return NULL;
+  }
+
+  Status = CopyRedfishResponse (Response, NewResponse);
+  if (EFI_ERROR (Status)) {
+    FreePool (NewResponse);
+    return NULL;
+  }
+
+  return NewResponse;
+}
+
+/**
+
+  Convert Unicode string to ASCII string. It's call responsibility to release returned buffer.
+
+  @param[in]  UnicodeStr      Unicode string to convert.
+
+  @retval     CHAR8 *         ASCII string returned.
+  @retval     NULL            Errors occur.
+
+**/
+CHAR8 *
+StringUnicodeToAscii (
+  IN EFI_STRING  UnicodeStr
+  )
+{
+  CHAR8       *AsciiStr;
+  UINTN       AsciiStrSize;
+  EFI_STATUS  Status;
+
+  if (IS_EMPTY_STRING (UnicodeStr)) {
+    return NULL;
+  }
+
+  AsciiStrSize = StrLen (UnicodeStr) + 1;
+  AsciiStr     = AllocatePool (AsciiStrSize);
+  if (AsciiStr == NULL) {
+    return NULL;
+  }
+
+  Status = UnicodeStrToAsciiStrS (UnicodeStr, AsciiStr, AsciiStrSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "UnicodeStrToAsciiStrS failed: %r\n", Status));
+    FreePool (AsciiStr);
+    return NULL;
+  }
+
+  return AsciiStr;
+}
+
+/**
+  Release REDFISH_HTTP_CACHE_DATA resource
+
+  @param[in]    Data    Pointer to REDFISH_HTTP_CACHE_DATA instance
+
+  @retval EFI_SUCCESS             REDFISH_HTTP_CACHE_DATA is released successfully.
+  @retval EFI_INVALID_PARAMETER   Data is NULL
+
+**/
+EFI_STATUS
+ReleaseHttpCacheData (
+  IN REDFISH_HTTP_CACHE_DATA  *Data
+  )
+{
+  if (Data == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Data->Uri != NULL) {
+    FreePool (Data->Uri);
+  }
+
+  if (Data->Response != NULL) {
+    if (Data->Response->Payload != NULL) {
+      RedfishFreeResponse (
+        Data->Response->StatusCode,
+        Data->Response->HeaderCount,
+        Data->Response->Headers,
+        Data->Response->Payload
+        );
+      FreePool (Data->Response);
+    }
+  }
+
+  FreePool (Data);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Create new cache data.
+
+  @param[in]    Uri       The URI string matching to this cache data.
+  @param[in]    Response  HTTP response.
+
+  @retval REDFISH_HTTP_CACHE_DATA *   Pointer to newly created cache data.
+  @retval NULL                        No memory available.
+
+**/
+REDFISH_HTTP_CACHE_DATA *
+NewHttpCacheData (
+  IN  EFI_STRING        Uri,
+  IN  REDFISH_RESPONSE  *Response
+  )
+{
+  REDFISH_HTTP_CACHE_DATA  *NewData;
+  UINTN                    Size;
+
+  if (IS_EMPTY_STRING (Uri) || (Response == NULL)) {
+    return NULL;
+  }
+
+  NewData = AllocateZeroPool (sizeof (REDFISH_HTTP_CACHE_DATA));
+  if (NewData == NULL) {
+    return NULL;
+  }
+
+  Size         = StrSize (Uri);
+  NewData->Uri = AllocateCopyPool (Size, Uri);
+  if (NewData->Uri == NULL) {
+    goto ON_ERROR;
+  }
+
+  NewData->Response = Response;
+  NewData->HitCount = 1;
+
+  return NewData;
+
+ON_ERROR:
+
+  if (NewData != NULL) {
+    ReleaseHttpCacheData (NewData);
+  }
+
+  return NULL;
+}
+
+/**
+  Search on given ListHeader for given URI string.
+
+  @param[in]    ListHeader  Target list to search.
+  @param[in]    Uri         Target URI to search.
+
+  @retval REDFISH_HTTP_CACHE_DATA   Target cache data is found.
+  @retval NULL                      No cache data with given URI is found.
+
+**/
+REDFISH_HTTP_CACHE_DATA *
+FindHttpCacheData (
+  IN  LIST_ENTRY  *ListHeader,
+  IN  EFI_STRING  Uri
+  )
+{
+  LIST_ENTRY               *List;
+  REDFISH_HTTP_CACHE_DATA  *Data;
+
+  if (IS_EMPTY_STRING (Uri)) {
+    return NULL;
+  }
+
+  if (IsListEmpty (ListHeader)) {
+    return NULL;
+  }
+
+  Data = NULL;
+  List = GetFirstNode (ListHeader);
+  while (!IsNull (ListHeader, List)) {
+    Data = REDFISH_HTTP_CACHE_FROM_LIST (List);
+
+    if (StrCmp (Data->Uri, Uri) == 0) {
+      return Data;
+    }
+
+    List = GetNextNode (ListHeader, List);
+  }
+
+  return NULL;
+}
+
+/**
+  Search on given ListHeader and return cache data with minimum hit count.
+
+  @param[in]    ListHeader  Target list to search.
+
+  @retval REDFISH_HTTP_CACHE_DATA   Target cache data is returned.
+  @retval NULL                      No cache data is found.
+
+**/
+REDFISH_HTTP_CACHE_DATA *
+FindUnusedHttpCacheData (
+  IN  LIST_ENTRY  *ListHeader
+  )
+{
+  LIST_ENTRY               *List;
+  REDFISH_HTTP_CACHE_DATA  *Data;
+  REDFISH_HTTP_CACHE_DATA  *UnusedData;
+  UINTN                    HitCount;
+
+  if (IsListEmpty (ListHeader)) {
+    return NULL;
+  }
+
+  Data       = NULL;
+  UnusedData = NULL;
+  HitCount   = 0;
+
+  List       = GetFirstNode (ListHeader);
+  Data       = REDFISH_HTTP_CACHE_FROM_LIST (List);
+  UnusedData = Data;
+  HitCount   = Data->HitCount;
+  List       = GetNextNode (ListHeader, List);
+
+  while (!IsNull (ListHeader, List)) {
+    Data = REDFISH_HTTP_CACHE_FROM_LIST (List);
+
+    if (Data->HitCount < HitCount) {
+      HitCount   = Data->HitCount;
+      UnusedData = Data;
+    }
+
+    List = GetNextNode (ListHeader, List);
+  }
+
+  return UnusedData;
+}
+
+/**
+  Delete a cache data by given cache instance.
+
+  @param[in]    List    Target cache list to be removed.
+  @param[in]    Data    Pointer to the instance to be deleted.
+
+  @retval EFI_SUCCESS   Cache data is removed.
+  @retval Others        Fail to remove cache data.
+
+**/
+EFI_STATUS
+DeleteHttpCacheData (
+  IN  REDFISH_HTTP_CACHE_LIST  *List,
+  IN  REDFISH_HTTP_CACHE_DATA  *Data
+  )
+{
+  if ((List == NULL) || (Data == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((REDFISH_HTTP_CACHE_DEBUG, "%a: delete: %s\n", __func__, Data->Uri));
+
+  RemoveEntryList (&Data->List);
+  --List->Count;
+
+  return ReleaseHttpCacheData (Data);
+}
+
+/**
+  Add new cache by given URI and HTTP response to specify List.
+
+  @param[in]    List      Target cache list to add.
+  @param[in]    Uri       The URI string matching to this cache data.
+  @param[in]    Response  HTTP response.
+
+  @retval EFI_SUCCESS   Cache data is added.
+  @retval Others        Fail to add cache data.
+
+**/
+EFI_STATUS
+AddHttpCacheData (
+  IN  REDFISH_HTTP_CACHE_LIST  *List,
+  IN  EFI_STRING               Uri,
+  IN  REDFISH_RESPONSE         *Response
+  )
+{
+  REDFISH_HTTP_CACHE_DATA  *NewData;
+  REDFISH_HTTP_CACHE_DATA  *OldData;
+  REDFISH_HTTP_CACHE_DATA  *UnusedData;
+  REDFISH_RESPONSE         *NewResponse;
+
+  if ((List == NULL) || IS_EMPTY_STRING (Uri) || (Response == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // If same cache data exist, replace it with latest one.
+  //
+  OldData = FindHttpCacheData (&List->Head, Uri);
+  if (OldData != NULL) {
+    DeleteHttpCacheData (List, OldData);
+  }
+
+  //
+  // Check capacity
+  //
+  if (List->Count >= List->Capacity) {
+    DEBUG ((REDFISH_HTTP_CACHE_DEBUG, "%a: list is full and retire unused cache\n", __func__));
+    UnusedData = FindUnusedHttpCacheData (&List->Head);
+    if (UnusedData == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    DeleteHttpCacheData (List, UnusedData);
+  }
+
+  //
+  // Clone a local copy
+  //
+  NewResponse = CloneRedfishResponse (Response);
+  if (NewResponse == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewData = NewHttpCacheData (Uri, NewResponse);
+  if (NewData == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  InsertTailList (&List->Head, &NewData->List);
+  ++List->Count;
+
+  DEBUG ((REDFISH_HTTP_CACHE_DEBUG, "%a: cache(%d/%d) %s\n", __func__, List->Count, List->Capacity, NewData->Uri));
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Release all cache from list.
+
+  @param[in]    CacheList    The list to be released.
+
+  @retval EFI_SUCCESS             All cache data are released.
+  @retval EFI_INVALID_PARAMETER   CacheList is NULL.
+
+**/
+EFI_STATUS
+ReleaseCacheList (
+  IN  REDFISH_HTTP_CACHE_LIST  *CacheList
+  )
+{
+  LIST_ENTRY               *List;
+  LIST_ENTRY               *Next;
+  REDFISH_HTTP_CACHE_DATA  *Data;
+
+  if (CacheList == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (IsListEmpty (&CacheList->Head)) {
+    return EFI_SUCCESS;
+  }
+
+  Data = NULL;
+  Next = NULL;
+  List = GetFirstNode (&CacheList->Head);
+  while (!IsNull (&CacheList->Head, List)) {
+    Data = REDFISH_HTTP_CACHE_FROM_LIST (List);
+    Next = GetNextNode (&CacheList->Head, List);
+
+    DeleteHttpCacheData (CacheList, Data);
+
+    List = Next;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Debug output the cache list.
+
+  @param[in]    Msg            Debug message string.
+  @param[in]    ErrorLevel     Output error level.
+  @param[in]    CacheList      Target list to dump.
+
+  @retval EFI_SUCCESS             Debug dump finished.
+  @retval EFI_INVALID_PARAMETER   HttpCacheList is NULL.
+
+**/
+EFI_STATUS
+DumpHttpCacheList (
+  IN  CONST CHAR8              *Msg,
+  IN  UINTN                    ErrorLevel,
+  IN  REDFISH_HTTP_CACHE_LIST  *CacheList
+  )
+{
+  LIST_ENTRY               *List;
+  REDFISH_HTTP_CACHE_DATA  *Data;
+  UINTN                    Index;
+
+  if (CacheList == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!IS_EMPTY_STRING (Msg)) {
+    DEBUG ((ErrorLevel, "%a\n", Msg));
+  }
+
+  if (IsListEmpty (&CacheList->Head)) {
+    DEBUG ((ErrorLevel, "list is empty\n"));
+    return EFI_NOT_FOUND;
+  }
+
+  DEBUG ((ErrorLevel, "list count: %d capacity: %d\n", CacheList->Count, CacheList->Capacity));
+  Data  = NULL;
+  Index = 0;
+  List  = GetFirstNode (&CacheList->Head);
+  while (!IsNull (&CacheList->Head, List)) {
+    Data = REDFISH_HTTP_CACHE_FROM_LIST (List);
+
+    DEBUG ((ErrorLevel, "%d) Uri: %s Hit: %d\n", ++Index, Data->Uri, Data->HitCount));
+
+    List = GetNextNode (&CacheList->Head, List);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Get redfish resource from given resource URI with cache mechanism
+  supported. It's caller's responsibility to Response by calling
+  RedfishFreeResponse ().
+
+  @param[in]  Service       Redfish service instance to make query.
+  @param[in]  Uri           Target resource URI.
+  @param[out] Response      HTTP response from redfish service.
+  @param[in]  UseCache      If it is TRUE, this function will search for
+                            cache first. If it is FALSE, this function
+                            will query Redfish URI directly.
+
+  @retval     EFI_SUCCESS     Resrouce is returned successfully.
+  @retval     Others          Errors occur.
+
+**/
+EFI_STATUS
+RedfishHttpGetResource (
+  IN  REDFISH_SERVICE   Service,
+  IN  EFI_STRING        Uri,
+  OUT REDFISH_RESPONSE  *Response,
+  IN  BOOLEAN           UseCache
+  )
+{
+  EFI_STATUS               Status;
+  CHAR8                    *AsciiUri;
+  REDFISH_HTTP_CACHE_DATA  *CacheData;
+  UINTN                    RetryCount;
+
+  if ((Service == NULL) || (Response == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (mRedfishHttpCachePrivate == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  AsciiUri   = NULL;
+  CacheData  = NULL;
+  RetryCount = 0;
+
+  //
+  // Search for cache list.
+  //
+  if (UseCache) {
+    CacheData = FindHttpCacheData (&mRedfishHttpCachePrivate->CacheList.Head, Uri);
+    if (CacheData != NULL) {
+      DEBUG ((REDFISH_HTTP_CACHE_DEBUG, "%a: cache hit! %s\n", __func__, Uri));
+
+      //
+      // Copy cached response to caller's buffer.
+      //
+      Status               = CopyRedfishResponse (CacheData->Response, Response);
+      CacheData->HitCount += 1;
+      return Status;
+    }
+  }
+
+  AsciiUri = StringUnicodeToAscii (Uri);
+  if (AsciiUri == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Get resource from redfish service.
+  //
+  do {
+    RetryCount += 1;
+    Status      = RedfishGetByUri (
+                    Service,
+                    AsciiUri,
+                    Response
+                    );
+    if (!EFI_ERROR (Status) || (RetryCount >= REDFISH_HTTP_GET_RETRY_MAX)) {
+      break;
+    }
+
+    //
+    // Retry when Redfish service is not ready.
+    //
+    if ((Response->StatusCode != NULL)) {
+      DEBUG_CODE (
+        DumpRedfishResponse (NULL, DEBUG_ERROR, Response);
+        );
+
+      if (*Response->StatusCode != HTTP_STATUS_500_INTERNAL_SERVER_ERROR) {
+        break;
+      }
+
+      FreePool (Response->StatusCode);
+      Response->StatusCode = NULL;
+    }
+
+    DEBUG ((DEBUG_WARN, "%a: RedfishGetByUri failed, retry (%d/%d)\n", __func__, RetryCount, REDFISH_HTTP_GET_RETRY_MAX));
+    gBS->Stall (REDFISH_HTTP_RETRY_WAIT);
+  } while (TRUE);
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: get %a failed (%d/%d): %r\n", __func__, AsciiUri, RetryCount, REDFISH_HTTP_GET_RETRY_MAX, Status));
+    if (Response->Payload != NULL) {
+      RedfishFreeResponse (
+        NULL,
+        0,
+        NULL,
+        Response->Payload
+        );
+      Response->Payload = NULL;
+    }
+
+    goto ON_RELEASE;
+  }
+
+  //
+  // Keep response in cache list
+  //
+  Status = AddHttpCacheData (&mRedfishHttpCachePrivate->CacheList, Uri, Response);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to cache %s: %r\n", __func__, Uri, Status));
+    goto ON_RELEASE;
+  }
+
+  DEBUG_CODE (
+    DumpHttpCacheList (__func__, REDFISH_HTTP_CACHE_DEBUG_DUMP, &mRedfishHttpCachePrivate->CacheList);
+    );
+
+ON_RELEASE:
+
+  if (AsciiUri != NULL) {
+    FreePool (AsciiUri);
+  }
+
+  return Status;
+}
+
+/**
+  Reset the cached data specified by given URI. When response data
+  returned by RedfishHttpResetResource() is modified, the response
+  data can not be used by other caller. Application calls this
+  function to make this data to be stale data and
+  RedfishHttpResetResource() will get latest data from remote server
+  again.
+
+  @param[in]  Uri           Target resource URI.
+
+  @retval     EFI_SUCCESS     Resrouce is reset successfully.
+  @retval     Others          Errors occur.
+
+**/
+EFI_STATUS
+RedfishHttpResetResource (
+  IN  EFI_STRING  Uri
+  )
+{
+  REDFISH_HTTP_CACHE_DATA  *CacheData;
+
+  if (IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (mRedfishHttpCachePrivate == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  CacheData = FindHttpCacheData (&mRedfishHttpCachePrivate->CacheList.Head, Uri);
+  if (CacheData == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  DeleteHttpCacheData (&mRedfishHttpCachePrivate->CacheList, CacheData);
+
+  return EFI_SUCCESS;
+}
+
+/**
+
+  Initial HTTP cache library instance.
+
+  @param[in] ImageHandle     The image handle.
+  @param[in] SystemTable     The system table.
+
+  @retval  EFI_SUCCESS  Initial library successfully.
+  @retval  Other        Return error status.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishHttpCacheConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  mRedfishHttpCachePrivate = AllocateZeroPool (sizeof (REDFISH_HTTP_CACHE_PRIVATE));
+  if (mRedfishHttpCachePrivate == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Initial cache list
+  //
+  mRedfishHttpCachePrivate->CacheList.Capacity = REDFISH_HTTP_CACHE_LIST_SIZE;
+  mRedfishHttpCachePrivate->CacheList.Count    = 0x00;
+  InitializeListHead (&mRedfishHttpCachePrivate->CacheList.Head);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Release allocated resource.
+
+  @param[in] ImageHandle       Handle that identifies the image to be unloaded.
+  @param[in] SystemTable      The system table.
+
+  @retval EFI_SUCCESS      The image has been unloaded.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishHttpCacheDestructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  if (mRedfishHttpCachePrivate != NULL) {
+    if (!IsListEmpty (&mRedfishHttpCachePrivate->CacheList.Head)) {
+      ReleaseCacheList (&mRedfishHttpCachePrivate->CacheList);
+    }
+
+    FreePool (mRedfishHttpCachePrivate);
+    mRedfishHttpCachePrivate = NULL;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/RedfishClientPkg/Library/RedfishHttpCacheLib/RedfishHttpCacheLib.inf
+++ b/RedfishClientPkg/Library/RedfishHttpCacheLib/RedfishHttpCacheLib.inf
@@ -1,0 +1,48 @@
+## @file
+#  Redfish HTTP cache library helps Redfish application to get Redfish resource
+#  from Redfish service with cache mechanism enabled.
+#
+#  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = RedfishHttpCacheLib
+  FILE_GUID                      = 21F8FEEC-023C-451D-824D-823058FD9481
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RedfishHttpCacheLib| DXE_DRIVER UEFI_DRIVER
+  CONSTRUCTOR                    = RedfishHttpCacheConstructor
+  DESTRUCTOR                     = RedfishHttpCacheDestructor
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  RedfishHttpCacheLibInternal.h
+  RedfishHttpCacheLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  RedfishPkg/RedfishPkg.dec
+  RedfishClientPkg/RedfishClientPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UefiBootServicesTableLib
+  MemoryAllocationLib
+  RedfishLib
+  UefiLib
+  RedfishDebugLib
+  ReportStatusCodeLib
+  PrintLib
+
+[depex]
+  TRUE
+

--- a/RedfishClientPkg/Library/RedfishHttpCacheLib/RedfishHttpCacheLibInternal.h
+++ b/RedfishClientPkg/Library/RedfishHttpCacheLib/RedfishHttpCacheLibInternal.h
@@ -1,0 +1,63 @@
+/** @file
+  This file defines the Redfish HTTP cache library internal headers.
+
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef REDFISH_HTTP_CACHE_INTERNAL_LIB_H_
+#define REDFISH_HTTP_CACHE_INTERNAL_LIB_H_
+
+#include <Uefi.h>
+#include <RedfishBase.h>
+
+#include <Library/UefiLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/RedfishLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/RedfishHttpCacheLib.h>
+#include <Library/RedfishDebugLib.h>
+#include <Library/ReportStatusCodeLib.h>
+#include <Library/PrintLib.h>
+
+#define REDFISH_HTTP_CACHE_LIST_SIZE   0x0F
+#define REDFISH_HTTP_GET_RETRY_MAX     0x0F
+#define REDFISH_HTTP_RETRY_WAIT        (2 * 1000000U)  ///< 1 second
+#define REDFISH_ERROR_MSG_MAX          128
+#define REDFISH_HTTP_ERROR_REPORT      "Redfish HTTP failure(0x%x): %a"
+#define REDFISH_HTTP_CACHE_DEBUG       DEBUG_VERBOSE
+#define REDFISH_HTTP_CACHE_DEBUG_DUMP  DEBUG_VERBOSE
+
+///
+/// Definition of REDFISH_HTTP_CACHE_DATA
+///
+typedef struct {
+  LIST_ENTRY          List;
+  EFI_STRING          Uri;
+  UINTN               HitCount;
+  REDFISH_RESPONSE    *Response;
+} REDFISH_HTTP_CACHE_DATA;
+
+#define REDFISH_HTTP_CACHE_FROM_LIST(a)  BASE_CR (a, REDFISH_HTTP_CACHE_DATA, List)
+
+///
+/// Definition of REDFISH_HTTP_CACHE_LIST
+///
+typedef struct {
+  LIST_ENTRY    Head;
+  UINTN         Count;
+  UINTN         Capacity;
+} REDFISH_HTTP_CACHE_LIST;
+
+///
+/// Definition of REDFISH_HTTP_CACHE_PRIVATE
+///
+typedef struct {
+  REDFISH_HTTP_CACHE_LIST    CacheList;
+} REDFISH_HTTP_CACHE_PRIVATE;
+
+#endif

--- a/RedfishClientPkg/Library/RedfishVersionLib/RedfishVersionLib.c
+++ b/RedfishClientPkg/Library/RedfishVersionLib/RedfishVersionLib.c
@@ -2,6 +2,7 @@
   Redfish version library implementation
 
   (C) Copyright 2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -10,15 +11,17 @@
 #include <Uefi.h>
 #include <RedfishBase.h>
 #include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/RedfishLib.h>
 #include <Library/JsonLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/RedfishVersionLib.h>
+#include <Library/RedfishHttpCacheLib.h>
 
 #define REDFISH_VERSION_DEFAULT_STRING  L"v1"
-#define REDFISH_ROOT_URI                "/redfish"
+#define REDFISH_ROOT_URI                L"/redfish"
 
 REDFISH_SERVICE  *mCacheService;
 EFI_STRING       mVersionCache;
@@ -26,7 +29,7 @@ UINTN            mVersionStringSize;
 
 /**
   Cache the redfish service version for later use so we don't have to query
-  HTTP request everytime.
+  HTTP request every time.
 
   @param[in]   Service  Redfish service instance
   @param[in]   Version  Version string to cache
@@ -65,8 +68,8 @@ CacheVersion (
 }
 
 /**
-  Query HTTP request to BMC with given redfish service and return redfish
-  version information. If there is troulbe to get Redfish version on BMC,
+  Query HTTP request to redfish service and return redfish
+  version information. If there is trouble to get Redfish version on service,
   The value of PcdDefaultRedfishVersion is returned.
 
   It's call responsibility to release returned buffer.
@@ -90,6 +93,7 @@ RedfishGetVersion (
   EDKII_JSON_VALUE  Value;
 
   VersionString = NULL;
+  ZeroMem (&Response, sizeof (REDFISH_RESPONSE));
 
   if (Service == NULL) {
     goto ON_ERROR;
@@ -105,13 +109,14 @@ RedfishGetVersion (
   //
   // Get resource from redfish service.
   //
-  Status = RedfishGetByUri (
+  Status = RedfishHttpGetResource (
              Service,
              REDFISH_ROOT_URI,
-             &Response
+             &Response,
+             TRUE
              );
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a, RedfishGetByService to %a failed: %r\n", __func__, REDFISH_ROOT_URI, Status));
+    DEBUG ((DEBUG_ERROR, "%a, RedfishGetByService to %s failed: %r\n", __func__, REDFISH_ROOT_URI, Status));
     if (Response.Payload != NULL) {
       RedfishDumpPayload (Response.Payload);
       RedfishFreeResponse (
@@ -151,18 +156,27 @@ ON_ERROR:
     VersionString = REDFISH_VERSION_DEFAULT_STRING;
   }
 
+  if (Response.Payload != NULL) {
+    RedfishFreeResponse (
+      Response.StatusCode,
+      Response.HeaderCount,
+      Response.Headers,
+      Response.Payload
+      );
+  }
+
   DEBUG ((DEBUG_MANAGEABILITY, "%a: Redfish version - %s\n", __func__, VersionString));
   return AllocateCopyPool (StrSize (VersionString), VersionString);
 }
 
 /**
 
-  Initial redfish version library instace.
+  Initial redfish version library instate.
 
   @param[in] ImageHandle     The image handle.
   @param[in] SystemTable     The system table.
 
-  @retval  EFI_SUCEESS  Install Boot manager menu success.
+  @retval  EFI_SUCCESS  Install Boot manager menu success.
   @retval  Other        Return error status.
 
 **/

--- a/RedfishClientPkg/Library/RedfishVersionLib/RedfishVersionLib.inf
+++ b/RedfishClientPkg/Library/RedfishVersionLib/RedfishVersionLib.inf
@@ -1,6 +1,7 @@
 ## @file
 #
 #  (C) Copyright 2022 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -31,11 +32,13 @@
 
 [LibraryClasses]
   BaseLib
+  BaseMemoryLib
   DebugLib
   MemoryAllocationLib
   PcdLib
   RedfishLib
   JsonLib
+  RedfishHttpCacheLib
 
 [Protocols]
 

--- a/RedfishClientPkg/RedfishClientLibs.dsc.inc
+++ b/RedfishClientPkg/RedfishClientLibs.dsc.inc
@@ -6,7 +6,7 @@
 # of EDKII network library classes.
 #
 # (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP<BR>
-# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -40,3 +40,4 @@
   RedfishVersionLib|RedfishClientPkg/Library/RedfishVersionLib/RedfishVersionLib.inf
   RedfishAddendumLib|RedfishClientPkg/Library/RedfishAddendumLib/RedfishAddendumLib.inf
   RedfishDebugLib|RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.inf
+  RedfishHttpCacheLib|RedfishClientPkg/Library/RedfishHttpCacheLib/RedfishHttpCacheLib.inf

--- a/RedfishClientPkg/RedfishClientPkg.dec
+++ b/RedfishClientPkg/RedfishClientPkg.dec
@@ -2,7 +2,7 @@
 # Redfish Client Package
 #
 # (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP<BR>
-# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -26,6 +26,7 @@
   EdkIIRedfishResourceConfigLib|Include/Library/EdkIIRedfishResourceConfigLib.h
   RedfishEventLib|Include/Library/RedfishEventLib.h
   RedfishVersionLib|Include/Library/RedfishVersionLib.h
+  RedfishHttpCacheLib|Include/Library/RedfishHttpCacheLib.h
 
 [LibraryClasses.Common.Private]
   ##  @libraryclass Redfish Helper Library

--- a/RedfishClientPkg/RedfishClientPkg.dsc
+++ b/RedfishClientPkg/RedfishClientPkg.dsc
@@ -2,7 +2,7 @@
 # Redfish Client Package
 #
 # (C) Copyright 2021 Hewlett-Packard Enterprise Development LP.
-# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -61,5 +61,6 @@
   RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.inf
   RedfishClientPkg/PrivateLibrary/RedfishLib/RedfishLib.inf
   RedfishClientPkg/Library/RedfishAddendumLib/RedfishAddendumLib.inf
+  RedfishClientPkg/Library/RedfishHttpCacheLib/RedfishHttpCacheLib.inf
 
   !include RedfishClientPkg/RedfishClient.dsc.inc


### PR DESCRIPTION
Introduce RedfishHttpCacheLib to improve HTTP GET performance in Redfish feature drivers. Feature drivers often query same
Redfish resource multiple times for different purpose. Add HTTP cache mechanism to improve the performance.

Signed-off-by: Nickle Wang <nicklew@nvidia.com>
Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nick Ramirez <nramirez@nvidia.com>