### PR TITLE
RedfishClientPkg/ConverterLib: check JSON value type

### DIFF
--- a/RedfishClientPkg/ConverterLib/src/RedfishCsCommon.c
+++ b/RedfishClientPkg/ConverterLib/src/RedfishCsCommon.c
@@ -1,5 +1,7 @@
 /** @file
 
+  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
   Copyright Notice:
   Copyright 2019-2024 Distributed Management Task Force, Inc. All rights reserved.
   License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-JSON-C-Struct-Converter/blob/master/LICENSE.md
@@ -829,6 +831,10 @@ GetRedfishPropertyStr (
     return RedfishCS_status_not_found;
   }
 
+  if (!json_is_string (TempJsonObj)) {
+    return RedfishCS_status_not_found;
+  }
+
   Status = allocateDuplicateStr (Cs, (char *)json_string_value (TempJsonObj), (void **)DstBuffer);
   return Status;
 }
@@ -912,6 +918,10 @@ GetRedfishPropertyInt64 (
   Status = allocateRecordCsMemory (Cs, sizeof (RedfishCS_int64), (void **)Dst);
   if (Status != RedfishCS_status_success) {
     return Status;
+  }
+
+  if (!json_is_integer (TempJsonObj)) {
+    return RedfishCS_status_not_found;
   }
 
   **Dst = (RedfishCS_int64)json_integer_value (TempJsonObj);


### PR DESCRIPTION
Check and see if JSON object type is desired type before getting its value. According to the Redfish schema, attribute value can be null value. Add this error handling to avoid system assertion while getting attribute value.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nick Ramirez <nramirez@nvidia.com>