### PR TITLE
Destroy structure leak

### DIFF
--- a/RedfishClientPkg/Features/Bios/v1_0_9/Common/BiosCommon.c
+++ b/RedfishClientPkg/Features/Bios/v1_0_9/Common/BiosCommon.c
@@ -247,7 +247,6 @@ ProvisioningBiosProperties (
                                  );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, ToJson() failed: %r\n", __func__, Status));
-    return Status;
   }
 
   //
@@ -257,6 +256,10 @@ ProvisioningBiosProperties (
                         JsonStructProtocol,
                         (EFI_REST_JSON_STRUCTURE_HEADER *)Bios
                         );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   return (PropertyChanged ? EFI_SUCCESS : EFI_NOT_FOUND);
 }

--- a/RedfishClientPkg/Features/BootOption/v1_0_4/Common/BootOptionCommon.c
+++ b/RedfishClientPkg/Features/BootOption/v1_0_4/Common/BootOptionCommon.c
@@ -334,7 +334,6 @@ ON_RELEASE:
                                  );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: ToJson() failed: %r\n", __func__, Status));
-    return Status;
   }
 
   //
@@ -344,6 +343,10 @@ ON_RELEASE:
                         JsonStructProtocol,
                         (EFI_REST_JSON_STRUCTURE_HEADER *)BootOption
                         );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   return (PropertyChanged ? EFI_SUCCESS : EFI_NOT_FOUND);
 }

--- a/RedfishClientPkg/Features/ComputerSystem/v1_13_0/Common/ComputerSystemCommon.c
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_13_0/Common/ComputerSystemCommon.c
@@ -263,7 +263,7 @@ ProvisioningComputerSystemProperties (
                                               );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: ToStructure failure: %r\n", __func__, Status));
-    return Status;
+    goto ON_RELEASE;
   }
 
   ComputerSystemCs = ComputerSystem->ComputerSystem;
@@ -365,7 +365,7 @@ ProvisioningComputerSystemProperties (
                                  );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: ToJson() failed: %r\n", __func__, Status));
-    return Status;
+    goto ON_RELEASE;
   }
 
   if (PropertyChanged) {
@@ -374,9 +374,13 @@ ProvisioningComputerSystemProperties (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Fail to remove Redfish unchangeable properties from ResultJson.\n", __func__));
       *ResultJson = NULL;
-      return Status;
+      goto ON_RELEASE;
     }
   }
+
+  Status = EFI_SUCCESS;
+
+ON_RELEASE:
 
   //
   // Release resource.
@@ -393,10 +397,17 @@ ProvisioningComputerSystemProperties (
     DestoryRedfishCharArray (ComputerSystemCsEmpty->Boot->BootOrder, ArraySize);
   }
 
-  JsonStructProtocol->DestoryStructure (
-                        JsonStructProtocol,
-                        (EFI_REST_JSON_STRUCTURE_HEADER *)ComputerSystemEmpty
-                        );
+  if (ComputerSystemEmpty != NULL) {
+    JsonStructProtocol->DestoryStructure (
+                          JsonStructProtocol,
+                          (EFI_REST_JSON_STRUCTURE_HEADER *)ComputerSystemEmpty
+                          );
+  }
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   return (PropertyChanged ? EFI_SUCCESS : EFI_NOT_FOUND);
 }
 

--- a/RedfishClientPkg/Features/ComputerSystemCollectionDxe/ComputerSystemCollectionDxe.c
+++ b/RedfishClientPkg/Features/ComputerSystemCollectionDxe/ComputerSystemCollectionDxe.c
@@ -174,11 +174,13 @@ HandleCollectionResource (
   CollectionCs = Collection->ComputerSystemCollection;
 
   if (*CollectionCs->Membersodata_count == 0) {
-    return EFI_NOT_FOUND;
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
   }
 
   if (IsLinkEmpty (&CollectionCs->Members)) {
-    return EFI_NOT_FOUND;
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
   }
 
   List = GetFirstLink (&CollectionCs->Members);
@@ -206,12 +208,16 @@ HandleCollectionResource (
     List = GetNextLink (&CollectionCs->Members, List);
   }
 
+  Status = EFI_SUCCESS;
+
+ON_RELEASE:
+
   //
   // Release resource.
   //
   Private->JsonStructProtocol->DestoryStructure (Private->JsonStructProtocol, (EFI_REST_JSON_STRUCTURE_HEADER *)Collection);
 
-  return EFI_SUCCESS;
+  return Status;
 }
 
 EFI_STATUS

--- a/RedfishClientPkg/Features/Memory/V1_7_1/Common/MemoryCommon.c
+++ b/RedfishClientPkg/Features/Memory/V1_7_1/Common/MemoryCommon.c
@@ -2133,7 +2133,6 @@ ProvisioningMemoryProperties (
                                  );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, ToJson() failed: %r\n", __func__, Status));
-    return Status;
   }
 
   //
@@ -2143,6 +2142,10 @@ ProvisioningMemoryProperties (
                         JsonStructProtocol,
                         (EFI_REST_JSON_STRUCTURE_HEADER *)Memory
                         );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   return (PropertyChanged ? EFI_SUCCESS : EFI_NOT_FOUND);
 }

--- a/RedfishClientPkg/Features/MemoryCollectionDxe/MemoryCollectionDxe.c
+++ b/RedfishClientPkg/Features/MemoryCollectionDxe/MemoryCollectionDxe.c
@@ -165,11 +165,13 @@ HandleCollectionResource (
   CollectionCs = Collection->MemoryCollection;
 
   if (*CollectionCs->Membersodata_count == 0) {
-    return EFI_NOT_FOUND;
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
   }
 
   if (IsLinkEmpty (&CollectionCs->Members)) {
-    return EFI_NOT_FOUND;
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
   }
 
   List = GetFirstLink (&CollectionCs->Members);
@@ -197,12 +199,15 @@ HandleCollectionResource (
     List = GetNextLink (&CollectionCs->Members, List);
   }
 
+  Status = EFI_SUCCESS;
+
+ON_RELEASE:
   //
   // Release resource.
   //
   Private->JsonStructProtocol->DestoryStructure (Private->JsonStructProtocol, (EFI_REST_JSON_STRUCTURE_HEADER *)Collection);
 
-  return EFI_SUCCESS;
+  return Status;
 }
 
 EFI_STATUS

--- a/RedfishClientPkg/Library/RedfishResourceIdentifyLibComputerSystem/v1_5_0/RedfishResourceIdentifyLibComputerSystem.c
+++ b/RedfishClientPkg/Library/RedfishResourceIdentifyLibComputerSystem/v1_5_0/RedfishResourceIdentifyLibComputerSystem.c
@@ -70,19 +70,20 @@ RedfishIdentifyResource (
   ComputerSystemCs = ComputerSystem->ComputerSystem;
 
   if (IS_EMPTY_STRING (ComputerSystemCs->UUID)) {
-    return FALSE;
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
   }
 
   Status = AsciiStrToGuid (ComputerSystemCs->UUID, &ResourceUuid);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, fail to get resource UUID: %r\n", __func__, Status));
-    return FALSE;
+    goto ON_RELEASE;
   }
 
   Status = NetLibGetSystemGuid (&SystemUuid);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, fail to get system UUID from SMBIOS: %r\n", __func__, Status));
-    return FALSE;
+    goto ON_RELEASE;
   }
 
   DEBUG ((REDFISH_DEBUG_TRACE, "%a, Identify: System: %g Resource: %g\n", __func__, &SystemUuid, &ResourceUuid));
@@ -91,6 +92,8 @@ RedfishIdentifyResource (
   } else {
     Status = EFI_UNSUPPORTED;
   }
+
+ON_RELEASE:
 
   mJsonStructProtocol->DestoryStructure (
                          mJsonStructProtocol,


### PR DESCRIPTION
This set contains fixes for proper deallocation of  the structures returned by JsonStructProtocol->ToStructure()