### PR TITLE
RedfishClientPkg/Features: Variable used before being initialized

### DIFF
--- a/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.c
+++ b/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.c
@@ -141,7 +141,7 @@ RedfishResourceConsumeResource (
                         );
   if (!EFI_ERROR (Status)) {
     DEBUG ((REDFISH_DEBUG_TRACE, "%a: @Redfish.Settings found: %s\n", __func__, PendingSettingUri));
-    SetRedfishSettingsObjectsUri (Private->Uri, PendingSettingUri);
+    SetRedfishSettingsObjectsUri (Uri, PendingSettingUri);
     Private->Uri     = PendingSettingUri;
     ExpectedResponse = &PendingSettingResponse;
   } else {

--- a/RedfishClientPkg/Features/BootOption/v1_0_4/Dxe/BootOptionDxe.c
+++ b/RedfishClientPkg/Features/BootOption/v1_0_4/Dxe/BootOptionDxe.c
@@ -130,7 +130,7 @@ RedfishResourceConsumeResource (
              );
   if (!EFI_ERROR (Status)) {
     DEBUG ((REDFISH_BOOT_OPTION_DEBUG_TRACE, "%a: @Redfish.Settings found: %s\n", __func__, PendingSettingUri));
-    SetRedfishSettingsObjectsUri (Private->Uri, PendingSettingUri);
+    SetRedfishSettingsObjectsUri (Uri, PendingSettingUri);
     Private->Uri     = PendingSettingUri;
     ExpectedResponse = &PendingSettingResponse;
   } else {

--- a/RedfishClientPkg/Features/ComputerSystem/v1_13_0/Dxe/ComputerSystemDxe.c
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_13_0/Dxe/ComputerSystemDxe.c
@@ -133,7 +133,7 @@ RedfishResourceConsumeResource (
              );
   if (!EFI_ERROR (Status)) {
     DEBUG ((REDFISH_DEBUG_TRACE, "%a: @Redfish.Settings found: %s\n", __func__, PendingSettingUri));
-    SetRedfishSettingsObjectsUri (Private->Uri, PendingSettingUri);
+    SetRedfishSettingsObjectsUri (Uri, PendingSettingUri);
     Private->Uri     = PendingSettingUri;
     ExpectedResponse = &PendingSettingResponse;
   } else {

--- a/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.c
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.c
@@ -134,7 +134,7 @@ RedfishResourceConsumeResource (
              );
   if (!EFI_ERROR (Status)) {
     DEBUG ((REDFISH_DEBUG_TRACE, "%a: @Redfish.Settings found: %s\n", __func__, PendingSettingUri));
-    SetRedfishSettingsObjectsUri (Private->Uri, PendingSettingUri);
+    SetRedfishSettingsObjectsUri (Uri, PendingSettingUri);
     Private->Uri     = PendingSettingUri;
     ExpectedResponse = &PendingSettingResponse;
   } else {

--- a/RedfishClientPkg/Features/Memory/V1_7_1/Dxe/MemoryDxe.c
+++ b/RedfishClientPkg/Features/Memory/V1_7_1/Dxe/MemoryDxe.c
@@ -134,7 +134,7 @@ RedfishResourceConsumeResource (
              );
   if (!EFI_ERROR (Status)) {
     DEBUG ((REDFISH_DEBUG_TRACE, "%a: @Redfish.Settings found: %s\n", __func__, PendingSettingUri));
-    SetRedfishSettingsObjectsUri (Private->Uri, PendingSettingUri);
+    SetRedfishSettingsObjectsUri (Uri, PendingSettingUri);
     Private->Uri     = PendingSettingUri;
     ExpectedResponse = &PendingSettingResponse;
   } else {


### PR DESCRIPTION
Private->Uri is initialized after calling SetRedfishSettingsObjectsUri() but it is used in SetRedfishSettingsObjectsUri function. Use input parameter "Uri" instead.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>