### PR TITLE
.github: Move review to GitHub pull request

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# EDK Redfish Client Maintainers
+*       @changab @igorkulchytskyy @nicklela

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+# Description
+
+<_Include a description of the change and why this change was made._>
+
+<_Delete lines in \<\> tags before creating the PR._>
+
+## How This Was Tested
+
+<_Describe the test(s) that were run to verify the changes._>

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ See [Maintainers.txt](Maintainers.txt).
 
 # Contributing
 
-The patch review process would be the same as edk2, and adding prefix **[edk2-redfish-client]**
-specifically for the patches against edk2-redfish-client repository. For more details, please
-see [CONTRIBUTING.md](CONTRIBUTING.md).
+The review process would be the same as [edk2](https://github.com/tianocore/edk2/tree/master?tab=readme-ov-file#code-contributions).
+For more details, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 # How to build (Ubuntu Environment)
 ## Prerequisite


### PR DESCRIPTION
Since edk2 and edk2-platform moved reviews to GitHub pull requests, we follow the same process and move edk2-redfish-clients reviews to GitHub pull requests.

- Add CODEOWNERS to automatically attach reviewer when pull request is created.
- Add pull request template to remind developer to add required information in pull request description.
- Update README.md.