### PR TITLE
RedfishClientPkg/ConverterLib: missing attributes

### DIFF
--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_0/Bios.V1_0_0.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_0/Bios.V1_0_0.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_1/Bios.V1_0_1.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_1/Bios.V1_0_1.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_2/Bios.V1_0_2.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_2/Bios.V1_0_2.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_3/Bios.V1_0_3.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_3/Bios.V1_0_3.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_4/Bios.V1_0_4.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_4/Bios.V1_0_4.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_5/Bios.V1_0_5.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_5/Bios.V1_0_5.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_6/Bios.V1_0_6.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_6/Bios.V1_0_6.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_7/Bios.V1_0_7.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_7/Bios.V1_0_7.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_8/Bios.V1_0_8.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_8/Bios.V1_0_8.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_9/Bios.V1_0_9.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_0_9/Bios.V1_0_9.c
@@ -370,11 +370,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_1_0/Bios.V1_1_0.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_1_0/Bios.V1_1_0.c
@@ -413,11 +413,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_1_1/Bios.V1_1_1.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_1_1/Bios.V1_1_1.c
@@ -413,11 +413,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_1_2/Bios.V1_1_2.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_1_2/Bios.V1_1_2.c
@@ -413,11 +413,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.

--- a/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_2_0/Bios.V1_2_0.c
+++ b/RedfishClientPkg/ConverterLib/src/Bios/Bios.V1_2_0/Bios.V1_2_0.c
@@ -413,11 +413,6 @@ static RedfishCS_status CS_To_JSON_Attributes(json_t *CsJson, char *Key, Redfish
     return RedfishCS_status_success;
   }
 
-  CsJson = json_object();
-  if (CsJson == NULL) {
-    return RedfishCS_status_unsupported;
-  }
-
   // Check if this is RedfishCS_Type_CS_EmptyProp.
   CsEmptyPropLinkToJson(CsJson, Key, &CSPtr->Prop);
   // No JSON property for this structure.


### PR DESCRIPTION
# Description

CsJson in CS_To_JSON_Attributes() is a parameter from caller but it gets created by json_object() again. As the result, caller never get the JSON attributes generated in this function and causing the issue.

## How This Was Tested

Tested on server platform
