### PR TITLE
Redfish schema version forward compatibility support

### DIFF
--- a/RedfishClientPkg/Features/Bios/v1_0_9/Common/BiosCommon.c
+++ b/RedfishClientPkg/Features/Bios/v1_0_9/Common/BiosCommon.c
@@ -14,6 +14,12 @@ CHAR8  BiosEmptyJson[] = "{\"@odata.id\": \"\", \"@odata.type\": \"#Bios.v1_0_9.
 
 REDFISH_RESOURCE_COMMON_PRIVATE  *mRedfishResourcePrivate             = NULL;
 EFI_HANDLE                       mRedfishResourceConfigProtocolHandle = NULL;
+REDFISH_SCHEMA_INFO              mSchemaInfo                          = {
+  { RESOURCE_SCHEMA        },
+  { RESOURCE_SCHEMA_MAJOR  },
+  { RESOURCE_SCHEMA_MINOR  },
+  { RESOURCE_SCHEMA_ERRATA }
+};
 
 /**
   Consume resource from given URI.
@@ -38,6 +44,7 @@ RedfishConsumeResourceCommon (
   EFI_REDFISH_BIOS_V1_0_9_CS        *BiosCs;
   EFI_STRING                        ConfigureLang;
   RedfishCS_Type_EmptyProp_CS_Data  *EmptyPropCs;
+  CHAR8                             *PatchedJson;
 
   if ((Private == NULL) || IS_EMPTY_STRING (Json)) {
     return EFI_INVALID_PARAMETER;
@@ -46,16 +53,25 @@ RedfishConsumeResourceCommon (
   Bios          = NULL;
   BiosCs        = NULL;
   ConfigureLang = NULL;
+  PatchedJson   = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, Json, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
 
   Status = Private->JsonStructProtocol->ToStructure (
                                           Private->JsonStructProtocol,
                                           NULL,
-                                          Json,
+                                          (PatchedJson == NULL ? Json : PatchedJson),
                                           (EFI_REST_JSON_STRUCTURE_HEADER **)&Bios
                                           );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, ToStructure() failed: %r\n", __func__, Status));
-    return Status;
+    goto ON_RELEASE;
   }
 
   BiosCs = Bios->Bios;
@@ -142,10 +158,16 @@ ON_RELEASE:
   //
   // Release resource.
   //
-  Private->JsonStructProtocol->DestoryStructure (
-                                 Private->JsonStructProtocol,
-                                 (EFI_REST_JSON_STRUCTURE_HEADER *)Bios
-                                 );
+  if (Bios != NULL) {
+    Private->JsonStructProtocol->DestoryStructure (
+                                   Private->JsonStructProtocol,
+                                   (EFI_REST_JSON_STRUCTURE_HEADER *)Bios
+                                   );
+  }
+
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+  }
 
   return EFI_SUCCESS;
 }
@@ -167,6 +189,7 @@ ProvisioningBiosProperties (
   CHAR8                         *AsciiStringValue;
   RedfishCS_EmptyProp_KeyValue  *PropertyVagueValues;
   UINT32                        VagueValueNumber;
+  CHAR8                         *PatchedJson;
 
   if ((JsonStructProtocol == NULL) || (ResultJson == NULL) || IS_EMPTY_STRING (InputJson) || IS_EMPTY_STRING (ConfigureLang)) {
     return EFI_INVALID_PARAMETER;
@@ -176,17 +199,26 @@ ProvisioningBiosProperties (
 
   *ResultJson     = NULL;
   PropertyChanged = FALSE;
+  Bios            = NULL;
+  PatchedJson     = NULL;
 
-  Bios   = NULL;
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, InputJson, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
   Status = JsonStructProtocol->ToStructure (
                                  JsonStructProtocol,
                                  NULL,
-                                 InputJson,
+                                 (PatchedJson == NULL ? InputJson : PatchedJson),
                                  (EFI_REST_JSON_STRUCTURE_HEADER **)&Bios
                                  );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, ToStructure failure: %r\n", __func__, Status));
-    return Status;
+    goto ON_RELEASE;
   }
 
   BiosCs = Bios->Bios;
@@ -253,13 +285,20 @@ ProvisioningBiosProperties (
     }
   }
 
+ON_RELEASE:
   //
   // Release resource.
   //
-  JsonStructProtocol->DestoryStructure (
-                        JsonStructProtocol,
-                        (EFI_REST_JSON_STRUCTURE_HEADER *)Bios
-                        );
+  if (Bios != NULL) {
+    JsonStructProtocol->DestoryStructure (
+                          JsonStructProtocol,
+                          (EFI_REST_JSON_STRUCTURE_HEADER *)Bios
+                          );
+  }
+
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+  }
 
   if (EFI_ERROR (Status)) {
     return Status;
@@ -737,8 +776,24 @@ RedfishIdentifyResourceCommon (
   EFI_STATUS                                   Status;
   EFI_STRING                                   EndOfChar;
   REDFISH_FEATURE_ARRAY_TYPE_CONFIG_LANG_LIST  ConfigLangList;
+  CHAR8                                        *PatchedJson;
 
-  Supported = RedfishIdentifyResource (Private->Uri, Json);
+  PatchedJson = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, Json, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
+  Supported = RedfishIdentifyResource (Private->Uri, (PatchedJson == NULL ? Json : PatchedJson));
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+    PatchedJson = NULL;
+  }
+
   if (Supported) {
     Status = RedfishFeatureGetUnifiedArrayTypeConfigureLang (RESOURCE_SCHEMA, RESOURCE_SCHEMA_VERSION, CONFIG_LANG_ARRAY_PATTERN, &ConfigLangList);
     if (EFI_ERROR (Status)) {

--- a/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.inf
+++ b/RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.inf
@@ -39,6 +39,7 @@
   UefiLib
   UefiDriverEntryPoint
   RedfishAddendumLib
+  PcdLib
 
 [Protocols]
   gEdkIIRedfishConfigHandlerProtocolGuid          ## PRODUCED
@@ -49,6 +50,7 @@
 [Pcd]
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport
 
 [Depex]
   TRUE

--- a/RedfishClientPkg/Features/BootOption/v1_0_4/Dxe/BootOptionDxe.inf
+++ b/RedfishClientPkg/Features/BootOption/v1_0_4/Dxe/BootOptionDxe.inf
@@ -41,6 +41,7 @@
   UefiBootManagerLib
   DevicePathLib
   BaseLib
+  PcdLib
 
 [Protocols]
   gEdkIIRedfishConfigHandlerProtocolGuid          ## PRODUCED
@@ -50,6 +51,7 @@
 [Pcd]
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport
 
 [Depex]
   TRUE

--- a/RedfishClientPkg/Features/ComputerSystem/v1_13_0/Common/ComputerSystemCommon.c
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_13_0/Common/ComputerSystemCommon.c
@@ -15,6 +15,12 @@ CHAR8  ComputerSystemEmptyJson[] = "{\"@odata.id\": \"\", \"@odata.type\": \"#Co
 
 REDFISH_RESOURCE_COMMON_PRIVATE  *mRedfishResourcePrivate             = NULL;
 EFI_HANDLE                       mRedfishResourceConfigProtocolHandle = NULL;
+REDFISH_SCHEMA_INFO              mSchemaInfo                          = {
+  { RESOURCE_SCHEMA        },
+  { RESOURCE_SCHEMA_MAJOR  },
+  { RESOURCE_SCHEMA_MINOR  },
+  { RESOURCE_SCHEMA_ERRATA }
+};
 
 /**
   Consume resource from given URI.
@@ -38,6 +44,7 @@ RedfishConsumeResourceCommon (
   EFI_REDFISH_COMPUTERSYSTEM_V1_13_0     *ComputerSystem;
   EFI_REDFISH_COMPUTERSYSTEM_V1_13_0_CS  *ComputerSystemCs;
   EFI_STRING                             ConfigureLang;
+  CHAR8                                  *PatchedJson;
 
   if ((Private == NULL) || IS_EMPTY_STRING (Json)) {
     return EFI_INVALID_PARAMETER;
@@ -46,16 +53,25 @@ RedfishConsumeResourceCommon (
   ComputerSystem   = NULL;
   ComputerSystemCs = NULL;
   ConfigureLang    = NULL;
+  PatchedJson      = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, Json, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
 
   Status = Private->JsonStructProtocol->ToStructure (
                                           Private->JsonStructProtocol,
                                           NULL,
-                                          Json,
+                                          (PatchedJson == NULL ? Json : PatchedJson),
                                           (EFI_REST_JSON_STRUCTURE_HEADER **)&ComputerSystem
                                           );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: ToStructure() failed: %r\n", __func__, Status));
-    return Status;
+    goto ON_RELEASE;
   }
 
   ComputerSystemCs = ComputerSystem->ComputerSystem;
@@ -205,10 +221,16 @@ ON_RELEASE:
   //
   // Release resource.
   //
-  Private->JsonStructProtocol->DestoryStructure (
-                                 Private->JsonStructProtocol,
-                                 (EFI_REST_JSON_STRUCTURE_HEADER *)ComputerSystem
-                                 );
+  if (ComputerSystem != NULL) {
+    Private->JsonStructProtocol->DestoryStructure (
+                                   Private->JsonStructProtocol,
+                                   (EFI_REST_JSON_STRUCTURE_HEADER *)ComputerSystem
+                                   );
+  }
+
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+  }
 
   return EFI_SUCCESS;
 }
@@ -232,6 +254,7 @@ ProvisioningComputerSystemProperties (
   CHAR8                                  *AsciiStringValue;
   CHAR8                                  **AsciiStringArrayValue;
   UINTN                                  ArraySize;
+  CHAR8                                  *PatchedJson;
 
   if ((JsonStructProtocol == NULL) || (ResultJson == NULL) || IS_EMPTY_STRING (InputJson) || IS_EMPTY_STRING (ConfigureLang)) {
     return EFI_INVALID_PARAMETER;
@@ -241,17 +264,26 @@ ProvisioningComputerSystemProperties (
 
   *ResultJson     = NULL;
   PropertyChanged = FALSE;
+  ComputerSystem  = NULL;
+  PatchedJson     = NULL;
 
-  ComputerSystem = NULL;
-  Status         = JsonStructProtocol->ToStructure (
-                                         JsonStructProtocol,
-                                         NULL,
-                                         InputJson,
-                                         (EFI_REST_JSON_STRUCTURE_HEADER **)&ComputerSystem
-                                         );
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, InputJson, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
+  Status = JsonStructProtocol->ToStructure (
+                                 JsonStructProtocol,
+                                 NULL,
+                                 (PatchedJson == NULL ? InputJson : PatchedJson),
+                                 (EFI_REST_JSON_STRUCTURE_HEADER **)&ComputerSystem
+                                 );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: ToStructure failure: %r\n", __func__, Status));
-    return Status;
+    goto ON_RELEASE;
   }
 
   ComputerSystemEmpty = NULL;
@@ -385,10 +417,12 @@ ON_RELEASE:
   //
   // Release resource.
   //
-  JsonStructProtocol->DestoryStructure (
-                        JsonStructProtocol,
-                        (EFI_REST_JSON_STRUCTURE_HEADER *)ComputerSystem
-                        );
+  if (ComputerSystem != NULL) {
+    JsonStructProtocol->DestoryStructure (
+                          JsonStructProtocol,
+                          (EFI_REST_JSON_STRUCTURE_HEADER *)ComputerSystem
+                          );
+  }
 
   //
   // Free memory allocated for Computersystem empty CS
@@ -402,6 +436,10 @@ ON_RELEASE:
                           JsonStructProtocol,
                           (EFI_REST_JSON_STRUCTURE_HEADER *)ComputerSystemEmpty
                           );
+  }
+
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
   }
 
   if (EFI_ERROR (Status)) {
@@ -872,8 +910,24 @@ RedfishIdentifyResourceCommon (
   EFI_STATUS                                   Status;
   EFI_STRING                                   EndOfChar;
   REDFISH_FEATURE_ARRAY_TYPE_CONFIG_LANG_LIST  ConfigLangList;
+  CHAR8                                        *PatchedJson;
 
-  Supported = RedfishIdentifyResource (Private->Uri, Json);
+  PatchedJson = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, Json, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
+  Supported = RedfishIdentifyResource (Private->Uri, (PatchedJson == NULL ? Json : PatchedJson));
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+    PatchedJson = NULL;
+  }
+
   if (Supported) {
     Status = RedfishFeatureGetUnifiedArrayTypeConfigureLang (RESOURCE_SCHEMA, RESOURCE_SCHEMA_VERSION, CONFIG_LANG_ARRAY_PATTERN, &ConfigLangList);
     if (EFI_ERROR (Status)) {

--- a/RedfishClientPkg/Features/ComputerSystem/v1_13_0/Dxe/ComputerSystemDxe.inf
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_13_0/Dxe/ComputerSystemDxe.inf
@@ -47,6 +47,7 @@
 [Pcd]
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport
 
 [Depex]
   TRUE

--- a/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.inf
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.inf
@@ -47,6 +47,7 @@
 [Pcd]
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport
 
 [Depex]
   TRUE

--- a/RedfishClientPkg/Features/Memory/V1_7_1/Common/MemoryCommon.c
+++ b/RedfishClientPkg/Features/Memory/V1_7_1/Common/MemoryCommon.c
@@ -14,6 +14,12 @@ CHAR8  MemoryEmptyJson[] = "{\"@odata.id\": \"\", \"@odata.type\": \"#Memory.v1_
 
 REDFISH_RESOURCE_COMMON_PRIVATE  *mRedfishResourcePrivate             = NULL;
 EFI_HANDLE                       mRedfishResourceConfigProtocolHandle = NULL;
+REDFISH_SCHEMA_INFO              mSchemaInfo                          = {
+  { RESOURCE_SCHEMA        },
+  { RESOURCE_SCHEMA_MAJOR  },
+  { RESOURCE_SCHEMA_MINOR  },
+  { RESOURCE_SCHEMA_ERRATA }
+};
 
 /**
   Consume resource from given URI.
@@ -37,6 +43,7 @@ RedfishConsumeResourceCommon (
   EFI_REDFISH_MEMORY_V1_7_1     *Memory;
   EFI_REDFISH_MEMORY_V1_7_1_CS  *MemoryCs;
   EFI_STRING                    ConfigureLang;
+  CHAR8                         *PatchedJson;
 
   if ((Private == NULL) || IS_EMPTY_STRING (Json)) {
     return EFI_INVALID_PARAMETER;
@@ -45,16 +52,25 @@ RedfishConsumeResourceCommon (
   Memory        = NULL;
   MemoryCs      = NULL;
   ConfigureLang = NULL;
+  PatchedJson   = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, Json, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
 
   Status = Private->JsonStructProtocol->ToStructure (
                                           Private->JsonStructProtocol,
                                           NULL,
-                                          Json,
+                                          (PatchedJson == NULL ? Json : PatchedJson),
                                           (EFI_REST_JSON_STRUCTURE_HEADER **)&Memory
                                           );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, ToStructure() failed: %r\n", __func__, Status));
-    return Status;
+    goto ON_RELEASE;
   }
 
   MemoryCs = Memory->Memory;
@@ -1264,12 +1280,18 @@ ON_RELEASE:
   //
   // Release resource.
   //
-  Private->JsonStructProtocol->DestoryStructure (
-                                 Private->JsonStructProtocol,
-                                 (EFI_REST_JSON_STRUCTURE_HEADER *)Memory
-                                 );
+  if (Memory != NULL) {
+    Private->JsonStructProtocol->DestoryStructure (
+                                   Private->JsonStructProtocol,
+                                   (EFI_REST_JSON_STRUCTURE_HEADER *)Memory
+                                   );
+  }
 
-  return EFI_SUCCESS;
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+  }
+
+  return Status;
 }
 
 EFI_STATUS
@@ -1293,6 +1315,7 @@ ProvisioningMemoryProperties (
   BOOLEAN                       *BooleanValue;
   INT32                         *IntegerValue;
   CHAR8                         **AsciiStringArrayValue;
+  CHAR8                         *PatchedJson;
 
   if ((JsonStructProtocol == NULL) || (ResultJson == NULL) || IS_EMPTY_STRING (InputJson) || IS_EMPTY_STRING (ConfigureLang)) {
     return EFI_INVALID_PARAMETER;
@@ -1302,17 +1325,26 @@ ProvisioningMemoryProperties (
 
   *ResultJson     = NULL;
   PropertyChanged = FALSE;
+  Memory          = NULL;
+  PatchedJson     = NULL;
 
-  Memory = NULL;
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, InputJson, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
   Status = JsonStructProtocol->ToStructure (
                                  JsonStructProtocol,
                                  NULL,
-                                 InputJson,
+                                 (PatchedJson == NULL ? InputJson : PatchedJson),
                                  (EFI_REST_JSON_STRUCTURE_HEADER **)&Memory
                                  );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a, ToStructure failure: %r\n", __func__, Status));
-    return Status;
+    goto ON_RELEASE;
   }
 
   MemoryCs = Memory->Memory;
@@ -2135,13 +2167,21 @@ ProvisioningMemoryProperties (
     DEBUG ((DEBUG_ERROR, "%a, ToJson() failed: %r\n", __func__, Status));
   }
 
+ON_RELEASE:
+
   //
   // Release resource.
   //
-  JsonStructProtocol->DestoryStructure (
-                        JsonStructProtocol,
-                        (EFI_REST_JSON_STRUCTURE_HEADER *)Memory
-                        );
+  if (Memory != NULL) {
+    JsonStructProtocol->DestoryStructure (
+                          JsonStructProtocol,
+                          (EFI_REST_JSON_STRUCTURE_HEADER *)Memory
+                          );
+  }
+
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+  }
 
   if (EFI_ERROR (Status)) {
     return Status;
@@ -2506,8 +2546,24 @@ RedfishIdentifyResourceCommon (
   EFI_STATUS                                   Status;
   EFI_STRING                                   EndOfChar;
   REDFISH_FEATURE_ARRAY_TYPE_CONFIG_LANG_LIST  ConfigLangList;
+  CHAR8                                        *PatchedJson;
 
-  Supported = RedfishIdentifyResource (Private->Uri, Json);
+  PatchedJson = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, Json, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
+  Supported = RedfishIdentifyResource (Private->Uri, (PatchedJson == NULL ? Json : PatchedJson));
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+    PatchedJson = NULL;
+  }
+
   if (Supported) {
     Status = RedfishFeatureGetUnifiedArrayTypeConfigureLang (RESOURCE_SCHEMA, RESOURCE_SCHEMA_VERSION, CONFIG_LANG_ARRAY_PATTERN, &ConfigLangList);
     if (EFI_ERROR (Status)) {

--- a/RedfishClientPkg/Features/Memory/V1_7_1/Dxe/MemoryDxe.inf
+++ b/RedfishClientPkg/Features/Memory/V1_7_1/Dxe/MemoryDxe.inf
@@ -37,6 +37,7 @@
   RedfishResourceIdentifyLib
   UefiLib
   UefiDriverEntryPoint
+  PcdLib
 
 [Protocols]
   gEdkIIRedfishConfigHandlerProtocolGuid          ## PRODUCED
@@ -46,6 +47,7 @@
 [Pcd]
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport
 
 [Depex]
   TRUE

--- a/RedfishClientPkg/Features/SecureBoot/v1_1_0/Dxe/SecureBootDxe.inf
+++ b/RedfishClientPkg/Features/SecureBoot/v1_1_0/Dxe/SecureBootDxe.inf
@@ -41,6 +41,7 @@
   UefiDriverEntryPoint
   RedfishAddendumLib
   UefiRuntimeServicesTableLib
+  PcdLib
 
 [Protocols]
   gEdkIIRedfishConfigHandlerProtocolGuid          ## PRODUCED
@@ -55,6 +56,7 @@
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishSystemRebootRequired
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport
 
 [Depex]
   TRUE

--- a/RedfishClientPkg/Include/Library/EdkIIRedfishResourceConfigLib.h
+++ b/RedfishClientPkg/Include/Library/EdkIIRedfishResourceConfigLib.h
@@ -192,4 +192,25 @@ GetSupportedSchemaVersion (
   OUT  REDFISH_SCHEMA_INFO  *SchemaInfo
   );
 
+/**
+  This function checks the schema version in InputJson to see if it matches
+  SchemaInfo. If not, it will replace "@odata.type" value to the schema information
+  provided by SchemaInfo. It's caller's responsibility to release OutputJson by calling
+  FreePool().
+
+  @param[in]  SchemaInfo          Desired schema information.
+  @param[in]  InputJson           JSON data on input.
+  @param[out] OutputJson          Patched JSON data on output.
+
+  @retval     EFI_SUCCESS         OutputJson is returned successfully.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+RedfishSetCompatibleSchemaVersion (
+  IN REDFISH_SCHEMA_INFO  *SchemaInfo,
+  IN CHAR8                *InputJson,
+  OUT CHAR8               **OutputJson
+  );
+
 #endif

--- a/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigInternal.h
+++ b/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigInternal.h
@@ -1,7 +1,7 @@
 /** @file
   Header file of EDKII Redfish Resource Config Library.
 
-  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -20,6 +20,17 @@
 #include <Library/RedfishFeatureUtilityLib.h>
 #include <Library/RedfishPlatformConfigLib.h>
 #include <Library/RedfishHttpLib.h>
+#include <Library/PrintLib.h>
+
+///
+/// Definition of SCHEMA_VERSION_COMPARE_RESULT
+///
+typedef enum {
+  SCHEMA_LEFT_EQUAL_TO_RIGHT = 0,
+  SCHEMA_LEFT_GREATER_THAN_RIGHT,
+  SCHEMA_LEFT_SMALLER_THAN_RIGHT,
+  SCHEMA_COMPARE_ERROR
+} SCHEMA_VERSION_COMPARE_RESULT;
 
 ///
 /// Definition of EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOLS
@@ -36,9 +47,12 @@ typedef struct {
   EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOLS    RedfishResourceConfig;
   EFI_HANDLE                                 CachedHandle;
   REDFISH_SCHEMA_INFO                        SchemaInfoCache;
+  BOOLEAN                                    CompatibleMode;
 } REDFISH_CONFIG_PROTOCOL_CACHE;
 
 #define SCHEMA_NAME_PREFIX         "x-UEFI-redfish-"
 #define SCHEMA_NAME_PREFIX_OFFSET  (AsciiStrLen (SCHEMA_NAME_PREFIX))
+#define SCHEMA_ODATA_TYPE          "@odata.type"
+#define SCHEMA_ODATA_TYPE_MAX_LEN  64
 
 #endif

--- a/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.c
+++ b/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.c
@@ -16,6 +16,367 @@ EDKII_REDFISH_FEATURE_INTERCHANGE_DATA_PROTOCOL  mRedfishFeatureInterchangeData;
 
 /**
 
+  Get schema information by parsing JsonText.
+
+  @param[in]  JsonText            Redfish data in JSON format.
+  @param[out] SchemaInfo          Returned schema information.
+
+  @retval     EFI_SUCCESS         Schema information is returned successfully.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+GetRedfishSchemaInfoFromJson (
+  IN  CHAR8                *JsonText,
+  OUT REDFISH_SCHEMA_INFO  *SchemaInfo
+  )
+{
+  EFI_STATUS        Status;
+  EDKII_JSON_VALUE  SchemaObj;
+  EDKII_JSON_VALUE  OdataTypeObj;
+  CONST CHAR8       *OdataTypeString;
+  CHAR8             *Seeker;
+  CHAR8             *TargetStr;
+
+  if (IS_EMPTY_STRING (JsonText) || (SchemaInfo == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  SchemaObj    = NULL;
+  OdataTypeObj = NULL;
+  Status       = EFI_SUCCESS;
+
+  SchemaObj = JsonLoadString (JsonText, 0, NULL);
+  if ((SchemaObj == NULL) || !JsonValueIsObject (SchemaObj)) {
+    return EFI_VOLUME_CORRUPTED;
+  }
+
+  OdataTypeObj = JsonObjectGetValue (JsonValueGetObject (SchemaObj), SCHEMA_ODATA_TYPE);
+  if (!JsonValueIsString (OdataTypeObj)) {
+    DEBUG ((DEBUG_ERROR, "%a, cannot find %a\n", __func__, SCHEMA_ODATA_TYPE));
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
+  }
+
+  OdataTypeString = JsonValueGetAsciiString (OdataTypeObj);
+  if (IS_EMPTY_STRING (OdataTypeString)) {
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a, odata.type: %a\n", __func__, OdataTypeString));
+
+  ZeroMem (SchemaInfo, sizeof (REDFISH_SCHEMA_INFO));
+  //
+  // Parse string to get schema name and version
+  //
+  Seeker = AsciiStrStr (OdataTypeString, "#");
+  if (Seeker == NULL) {
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
+  }
+
+  TargetStr = Seeker + 1;
+
+  Seeker = AsciiStrStr (TargetStr, ".");
+  if (Seeker == NULL) {
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
+  }
+
+  AsciiStrnCpyS (SchemaInfo->Schema, REDFISH_SCHEMA_STRING_SIZE, TargetStr, (Seeker - TargetStr));
+
+  //
+  // Schema version major number
+  //
+  TargetStr = Seeker + 1;
+  if (TargetStr[0] != 'v') {
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
+  }
+
+  TargetStr += 1;
+
+  Seeker = AsciiStrStr (TargetStr, "_");
+  if (Seeker == NULL) {
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
+  }
+
+  AsciiStrnCpyS (SchemaInfo->Major, REDFISH_SCHEMA_VERSION_SIZE, TargetStr, (Seeker - TargetStr));
+
+  //
+  // Schema version minor number
+  //
+  TargetStr = Seeker + 1;
+  Seeker    = AsciiStrStr (TargetStr, "_");
+  if (Seeker == NULL) {
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
+  }
+
+  AsciiStrnCpyS (SchemaInfo->Minor, REDFISH_SCHEMA_VERSION_SIZE, TargetStr, (Seeker - TargetStr));
+
+  //
+  // Schema version errata number
+  //
+  TargetStr = Seeker + 1;
+  Seeker    = AsciiStrStr (TargetStr, ".");
+  if (Seeker == NULL) {
+    Status = EFI_NOT_FOUND;
+    goto ON_RELEASE;
+  }
+
+  AsciiStrnCpyS (SchemaInfo->Errata, REDFISH_SCHEMA_VERSION_SIZE, TargetStr, (Seeker - TargetStr));
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a, schema: %a\n", __func__, SchemaInfo->Schema));
+  DEBUG ((DEBUG_MANAGEABILITY, "%a, major:  %a\n", __func__, SchemaInfo->Major));
+  DEBUG ((DEBUG_MANAGEABILITY, "%a, minor:  %a\n", __func__, SchemaInfo->Minor));
+  DEBUG ((DEBUG_MANAGEABILITY, "%a, errata: %a\n", __func__, SchemaInfo->Errata));
+
+ON_RELEASE:
+
+  if (SchemaObj != NULL) {
+    JsonValueFree (SchemaObj);
+  }
+
+  return Status;
+}
+
+/**
+  This function checks the schema version in InputJson to see if it matches
+  SchemaInfo. If not, it will replace "@odata.type" value to the schema information
+  provided by SchemaInfo. It's caller's responsibility to release OutputJson by calling
+  FreePool().
+
+  @param[in]  SchemaInfo          Desired schema information.
+  @param[in]  InputJson           JSON data on input.
+  @param[out] OutputJson          Patched JSON data on output.
+
+  @retval     EFI_SUCCESS         OutputJson is returned successfully.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+RedfishSetCompatibleSchemaVersion (
+  IN REDFISH_SCHEMA_INFO  *SchemaInfo,
+  IN CHAR8                *InputJson,
+  OUT CHAR8               **OutputJson
+  )
+{
+  EFI_STATUS           Status;
+  REDFISH_SCHEMA_INFO  JsonSchemaInfo;
+  EDKII_JSON_VALUE     PatchedObj;
+  EDKII_JSON_VALUE     OdataTypeObj;
+  CHAR8                OdataTypeString[SCHEMA_ODATA_TYPE_MAX_LEN];
+
+  if ((SchemaInfo == NULL) || IS_EMPTY_STRING (InputJson) || (OutputJson == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *OutputJson  = NULL;
+  PatchedObj   = NULL;
+  OdataTypeObj = NULL;
+  Status       = GetRedfishSchemaInfoFromJson (InputJson, &JsonSchemaInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Can not get schema information: %r\n", __func__, Status));
+    return Status;
+  }
+
+  if (AsciiStrCmp (JsonSchemaInfo.Schema, SchemaInfo->Schema) != 0) {
+    //
+    // Wrong schema
+    //
+    return EFI_UNSUPPORTED;
+  }
+
+  if ((AsciiStrCmp (JsonSchemaInfo.Major, SchemaInfo->Major) == 0) &&
+      (AsciiStrCmp (JsonSchemaInfo.Minor, SchemaInfo->Minor) == 0) &&
+      (AsciiStrCmp (JsonSchemaInfo.Errata, SchemaInfo->Errata) == 0)
+      )
+  {
+    //
+    // Perfect match. We don't need to do anything.
+    //
+    return EFI_SUCCESS;
+  }
+
+  DEBUG ((DEBUG_WARN, "%a, Compatible mode enabled!!\n", __func__));
+  AsciiSPrint (OdataTypeString, sizeof (OdataTypeString), "#%a.v%a_%a_%a.%a", SchemaInfo->Schema, SchemaInfo->Major, SchemaInfo->Minor, SchemaInfo->Errata, SchemaInfo->Schema);
+
+  PatchedObj = JsonLoadString (InputJson, 0, NULL);
+  if (!JsonValueIsObject (PatchedObj)) {
+    return EFI_VOLUME_CORRUPTED;
+  }
+
+  OdataTypeObj = JsonValueInitAsciiString (OdataTypeString);
+  if (!JsonValueIsString (OdataTypeObj)) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ON_RELEASE;
+  }
+
+  Status = JsonObjectSetValue (PatchedObj, SCHEMA_ODATA_TYPE, OdataTypeObj);
+  if (!EFI_ERROR (Status)) {
+    *OutputJson = JsonDumpString (PatchedObj, EDKII_JSON_COMPACT);
+    if (*OutputJson == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+    }
+  }
+
+ON_RELEASE:
+
+  if (PatchedObj != NULL) {
+    JsonValueFree (PatchedObj);
+  }
+
+  return Status;
+}
+
+/**
+
+  This function checks to see if the protocol of supporting target schema is cached or not.
+
+  @param[in]  ProtocolCache   Instance of protocol cache.
+  @param[in]  TargetSchema    Target schema.
+
+  @retval     TRUE   Protocol of supporting target schema is cached.
+  @retval     FALSE  Protocol of supporting target schema is not found in cache.
+
+**/
+BOOLEAN
+IsProtocolCached (
+  IN REDFISH_CONFIG_PROTOCOL_CACHE  *ProtocolCache,
+  IN REDFISH_SCHEMA_INFO            *TargetSchema
+  )
+{
+  if ((ProtocolCache == NULL) || (TargetSchema == NULL)) {
+    return FALSE;
+  }
+
+  if ((AsciiStrCmp (TargetSchema->Schema, ProtocolCache->SchemaInfoCache.Schema) != 0)) {
+    return FALSE;
+  }
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport) && ProtocolCache->CompatibleMode) {
+    DEBUG ((
+      DEBUG_WARN,
+      "Compatible mode enabled!! Select cache %a %a.%a.%a to support %a %a.%a.%a\n",
+      ProtocolCache->SchemaInfoCache.Schema,
+      ProtocolCache->SchemaInfoCache.Major,
+      ProtocolCache->SchemaInfoCache.Minor,
+      ProtocolCache->SchemaInfoCache.Errata,
+      TargetSchema->Schema,
+      TargetSchema->Major,
+      TargetSchema->Minor,
+      TargetSchema->Errata
+      ));
+    return TRUE;
+  }
+
+  if ((AsciiStrCmp (TargetSchema->Major, ProtocolCache->SchemaInfoCache.Major) == 0) &&
+      (AsciiStrCmp (TargetSchema->Minor, ProtocolCache->SchemaInfoCache.Minor) == 0) &&
+      (AsciiStrCmp (TargetSchema->Errata, ProtocolCache->SchemaInfoCache.Errata) == 0))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+
+  This function compares two schema version and return the result.
+
+  @param[in]  SchemaLeft    Schema on left.
+  @param[in]  SchemaRight   Schema on right.
+
+  @retval    SCHEMA_VERSION_COMPARE_RESULT
+
+**/
+SCHEMA_VERSION_COMPARE_RESULT
+CompareSchemaVersion (
+  IN REDFISH_SCHEMA_INFO  *SchemaLeft,
+  IN REDFISH_SCHEMA_INFO  *SchemaRight
+  )
+{
+  UINTN  LeftVersionNumber;
+  UINTN  RightVersionNumber;
+
+  if ((SchemaLeft == NULL) || (SchemaRight == NULL)) {
+    return SCHEMA_COMPARE_ERROR;
+  }
+
+  LeftVersionNumber  = AsciiStrDecimalToUintn (SchemaLeft->Major);
+  RightVersionNumber = AsciiStrDecimalToUintn (SchemaRight->Major);
+  if (LeftVersionNumber > RightVersionNumber) {
+    return SCHEMA_LEFT_GREATER_THAN_RIGHT;
+  } else if (LeftVersionNumber < RightVersionNumber) {
+    return SCHEMA_LEFT_SMALLER_THAN_RIGHT;
+  }
+
+  LeftVersionNumber  = AsciiStrDecimalToUintn (SchemaLeft->Minor);
+  RightVersionNumber = AsciiStrDecimalToUintn (SchemaRight->Minor);
+  if (LeftVersionNumber > RightVersionNumber) {
+    return SCHEMA_LEFT_GREATER_THAN_RIGHT;
+  } else if (LeftVersionNumber < RightVersionNumber) {
+    return SCHEMA_LEFT_SMALLER_THAN_RIGHT;
+  }
+
+  LeftVersionNumber  = AsciiStrDecimalToUintn (SchemaLeft->Errata);
+  RightVersionNumber = AsciiStrDecimalToUintn (SchemaRight->Errata);
+  if (LeftVersionNumber > RightVersionNumber) {
+    return SCHEMA_LEFT_GREATER_THAN_RIGHT;
+  } else if (LeftVersionNumber < RightVersionNumber) {
+    return SCHEMA_LEFT_SMALLER_THAN_RIGHT;
+  }
+
+  return SCHEMA_LEFT_EQUAL_TO_RIGHT;
+}
+
+/**
+
+  This function keep protocol data to cache instance.
+
+  @param[in,out]  ProtocolCache     Cache instance to keep protocol data.
+  @param[in]      ProtocolHandle    Protocol handle.
+  @param[in]      ProtocolPointer   Pointer to protocol instance.
+  @param[in]      ProtocolSchema    Pointer to protocol schema.
+  @param[in]      CompatibleEnabled TRUE when compatible mode is enabled. FALSE otherwise.
+  @param[in]      IsVersion2        ProtocolPointer is config2 protocol or not.
+
+  @retval     EFI_SUCCESS         Protocol data is properly cached.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+CacheConfigProtocol (
+  IN OUT REDFISH_CONFIG_PROTOCOL_CACHE  *ProtocolCache,
+  IN EFI_HANDLE                         ProtocolHandle,
+  IN VOID                               *ProtocolPointer,
+  IN REDFISH_SCHEMA_INFO                *ProtocolSchema,
+  IN BOOLEAN                            CompatibleEnabled,
+  IN BOOLEAN                            IsVersion2
+  )
+{
+  if ((ProtocolCache == NULL) || (ProtocolHandle == NULL) || (ProtocolPointer == NULL) || (ProtocolSchema == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ProtocolCache->CompatibleMode = CompatibleEnabled;
+  ProtocolCache->CachedHandle   = ProtocolHandle;
+  if (IsVersion2) {
+    ProtocolCache->RedfishResourceConfig.Config2Protocol = ProtocolPointer;
+  } else {
+    ProtocolCache->RedfishResourceConfig.ConfigProtocol = ProtocolPointer;
+  }
+
+  CopyMem (&ProtocolCache->SchemaInfoCache, ProtocolSchema, sizeof (REDFISH_SCHEMA_INFO));
+
+  return EFI_SUCCESS;
+}
+
+/**
+
   Get schema information by given protocol and service instance if JsonText
   is NULL or empty. When JsonText is provided by caller, this function read
   schema information from JsonText.
@@ -40,17 +401,15 @@ GetRedfishSchemaInfo (
   OUT REDFISH_SCHEMA_INFO               *SchemaInfo
   )
 {
-  EFI_STATUS                      Status;
-  REDFISH_RESPONSE                Response;
-  CHAR8                           *JsonData;
-  EFI_REST_JSON_STRUCTURE_HEADER  *Header;
+  EFI_STATUS        Status;
+  REDFISH_RESPONSE  Response;
+  CHAR8             *JsonData;
 
-  if ((RedfishService == NULL) || (JsonStructProtocol == NULL) || IS_EMPTY_STRING (Uri) || (SchemaInfo == NULL)) {
+  if (((RedfishService == NULL) && IS_EMPTY_STRING (Uri) && IS_EMPTY_STRING (JsonText)) || (SchemaInfo == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 
   JsonData = NULL;
-  Header   = NULL;
   ZeroMem (&Response, sizeof (Response));
   if (IS_EMPTY_STRING (JsonText)) {
     Status = RedfishHttpGetResource (RedfishService, Uri, NULL, &Response, TRUE);
@@ -72,30 +431,18 @@ GetRedfishSchemaInfo (
   }
 
   //
-  // Convert JSON text to C structure.
+  // Get schema information from JSON data.
   //
-  Status = JsonStructProtocol->ToStructure (
-                                 JsonStructProtocol,
-                                 NULL,
-                                 JsonData,
-                                 &Header
-                                 );
+  Status = GetRedfishSchemaInfoFromJson (JsonData, SchemaInfo);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: ToStructure() failed: %r\n", __func__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: cannot get schema information: %r\n", __func__, Status));
     goto ON_RELEASE;
   }
-
-  AsciiStrCpyS (SchemaInfo->Schema, REDFISH_SCHEMA_STRING_SIZE, Header->JsonRsrcIdentifier.NameSpace.ResourceTypeName);
-  AsciiStrCpyS (SchemaInfo->Major, REDFISH_SCHEMA_VERSION_SIZE, Header->JsonRsrcIdentifier.NameSpace.MajorVersion);
-  AsciiStrCpyS (SchemaInfo->Minor, REDFISH_SCHEMA_VERSION_SIZE, Header->JsonRsrcIdentifier.NameSpace.MinorVersion);
-  AsciiStrCpyS (SchemaInfo->Errata, REDFISH_SCHEMA_VERSION_SIZE, Header->JsonRsrcIdentifier.NameSpace.ErrataVersion);
 
 ON_RELEASE:
   //
   // Release resource.
   //
-  JsonStructProtocol->DestoryStructure (JsonStructProtocol, Header);
-
   if (JsonData != NULL) {
     FreePool (JsonData);
   }
@@ -244,11 +591,15 @@ GetRedfishResourceConfigProtocol (
 {
   EFI_STATUS                              Status;
   EFI_HANDLE                              *HandleBuffer;
+  EFI_HANDLE                              CompatibleHandle;
   UINTN                                   NumberOfHandles;
   UINTN                                   Index;
   EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *Protocol;
+  EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *CompatibleProtocol;
   REDFISH_SCHEMA_INFO                     SchemaInfo;
+  REDFISH_SCHEMA_INFO                     CompatibleSchemaInfo;
   BOOLEAN                                 Found;
+  SCHEMA_VERSION_COMPARE_RESULT           SchemaVersionResult;
 
   if (IS_EMPTY_STRING (Schema->Schema) ||
       IS_EMPTY_STRING (Schema->Major) ||
@@ -259,12 +610,18 @@ GetRedfishResourceConfigProtocol (
     return NULL;
   }
 
+  HandleBuffer        = NULL;
+  CompatibleHandle    = NULL;
+  NumberOfHandles     = 0;
+  Protocol            = NULL;
+  CompatibleProtocol  = NULL;
+  SchemaVersionResult = SCHEMA_COMPARE_ERROR;
+
+  //
+  // Search protocol cache to see if we can return protocol immediately or not.
+  //
   if ((mRedfishResourceConfigCache != NULL) && (mRedfishResourceConfigCache->RedfishResourceConfig.ConfigProtocol != NULL)) {
-    if ((AsciiStrCmp (Schema->Schema, mRedfishResourceConfigCache->SchemaInfoCache.Schema) == 0) &&
-        (AsciiStrCmp (Schema->Major, mRedfishResourceConfigCache->SchemaInfoCache.Major) == 0) &&
-        (AsciiStrCmp (Schema->Minor, mRedfishResourceConfigCache->SchemaInfoCache.Minor) == 0) &&
-        (AsciiStrCmp (Schema->Errata, mRedfishResourceConfigCache->SchemaInfoCache.Errata) == 0))
-    {
+    if (IsProtocolCached (mRedfishResourceConfigCache, Schema)) {
       if (Handle != NULL) {
         *Handle = mRedfishResourceConfigCache->CachedHandle;
       }
@@ -301,26 +658,84 @@ GetRedfishResourceConfigProtocol (
       continue;
     }
 
-    if ((AsciiStrCmp (Schema->Schema, SchemaInfo.Schema) == 0) &&
-        (AsciiStrCmp (Schema->Major, SchemaInfo.Major) == 0) &&
-        (AsciiStrCmp (Schema->Minor, SchemaInfo.Minor) == 0) &&
-        (AsciiStrCmp (Schema->Errata, SchemaInfo.Errata) == 0))
-    {
+    if ((AsciiStrCmp (Schema->Schema, SchemaInfo.Schema) != 0)) {
+      continue;
+    }
+
+    //
+    // Compare schema version
+    //
+    SchemaVersionResult = CompareSchemaVersion (Schema, &SchemaInfo);
+    if (SchemaVersionResult == SCHEMA_COMPARE_ERROR) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a, compare schema error %a %a.%a.%a vs %a %a.%a.%a\n",
+        __func__,
+        Schema->Schema,
+        Schema->Major,
+        Schema->Minor,
+        Schema->Errata,
+        SchemaInfo.Schema,
+        SchemaInfo.Major,
+        SchemaInfo.Minor,
+        SchemaInfo.Errata
+        ));
+      continue;
+    }
+
+    if (SchemaVersionResult == SCHEMA_LEFT_EQUAL_TO_RIGHT) {
+      //
+      // Perfect match
+      //
       Found = TRUE;
       break;
+    } else {
+      if (!PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+        continue;
+      }
+
+      //
+      // Check to see if this schema version is Compatible or not.
+      // The rule is: we can use old schema version to support new schema version
+      // because old/deprecated attributes will still be in new schema version.
+      //
+      if (SchemaVersionResult == SCHEMA_LEFT_SMALLER_THAN_RIGHT) {
+        continue;
+      }
+
+      CompatibleHandle   = HandleBuffer[Index];
+      CompatibleProtocol = Protocol;
+      CopyMem (&CompatibleSchemaInfo, &SchemaInfo, sizeof (REDFISH_SCHEMA_INFO));
     }
   }
 
   if (Found) {
-    if (mRedfishResourceConfigCache != NULL) {
-      mRedfishResourceConfigCache->CachedHandle                         = HandleBuffer[Index];
-      mRedfishResourceConfigCache->RedfishResourceConfig.ConfigProtocol = Protocol;
-      CopyMem (&mRedfishResourceConfigCache->SchemaInfoCache, Schema, sizeof (REDFISH_SCHEMA_INFO));
-    }
-
+    CacheConfigProtocol (mRedfishResourceConfigCache, HandleBuffer[Index], Protocol, Schema, FALSE, FALSE);
     if (Handle != NULL) {
       *Handle = HandleBuffer[Index];
     }
+  } else if (CompatibleHandle != NULL) {
+    DEBUG ((
+      DEBUG_WARN,
+      "Compatible mode enabled!! Select %a %a.%a.%a to support %a %a.%a.%a\n",
+      CompatibleSchemaInfo.Schema,
+      CompatibleSchemaInfo.Major,
+      CompatibleSchemaInfo.Minor,
+      CompatibleSchemaInfo.Errata,
+      Schema->Schema,
+      Schema->Major,
+      Schema->Minor,
+      Schema->Errata
+      ));
+
+    CacheConfigProtocol (mRedfishResourceConfigCache, CompatibleHandle, CompatibleProtocol, &CompatibleSchemaInfo, TRUE, FALSE);
+
+    if (Handle != NULL) {
+      *Handle = CompatibleHandle;
+    }
+
+    Found    = TRUE;
+    Protocol = CompatibleProtocol;
   }
 
   FreePool (HandleBuffer);
@@ -348,11 +763,15 @@ GetRedfishResourceConfig2Protocol (
 {
   EFI_STATUS                               Status;
   EFI_HANDLE                               *HandleBuffer;
+  EFI_HANDLE                               CompatibleHandle;
   UINTN                                    NumberOfHandles;
   UINTN                                    Index;
   EDKII_REDFISH_RESOURCE_CONFIG2_PROTOCOL  *Protocol;
+  EDKII_REDFISH_RESOURCE_CONFIG2_PROTOCOL  *CompatibleProtocol;
   REDFISH_SCHEMA_INFO                      SchemaInfo;
+  REDFISH_SCHEMA_INFO                      CompatibleSchemaInfo;
   BOOLEAN                                  Found;
+  SCHEMA_VERSION_COMPARE_RESULT            SchemaVersionResult;
 
   if (IS_EMPTY_STRING (Schema->Schema) ||
       IS_EMPTY_STRING (Schema->Major) ||
@@ -363,12 +782,18 @@ GetRedfishResourceConfig2Protocol (
     return NULL;
   }
 
+  HandleBuffer        = NULL;
+  CompatibleHandle    = NULL;
+  NumberOfHandles     = 0;
+  Protocol            = NULL;
+  CompatibleProtocol  = NULL;
+  SchemaVersionResult = SCHEMA_COMPARE_ERROR;
+
+  //
+  // Search protocol cache to see if we can return protocol immediately or not.
+  //
   if ((mRedfishResourceConfig2Cache != NULL) && (mRedfishResourceConfig2Cache->RedfishResourceConfig.Config2Protocol != NULL)) {
-    if ((AsciiStrCmp (Schema->Schema, mRedfishResourceConfig2Cache->SchemaInfoCache.Schema) == 0) &&
-        (AsciiStrCmp (Schema->Major, mRedfishResourceConfig2Cache->SchemaInfoCache.Major) == 0) &&
-        (AsciiStrCmp (Schema->Minor, mRedfishResourceConfig2Cache->SchemaInfoCache.Minor) == 0) &&
-        (AsciiStrCmp (Schema->Errata, mRedfishResourceConfig2Cache->SchemaInfoCache.Errata) == 0))
-    {
+    if (IsProtocolCached (mRedfishResourceConfig2Cache, Schema)) {
       if (Handle != NULL) {
         *Handle = mRedfishResourceConfig2Cache->CachedHandle;
       }
@@ -405,26 +830,84 @@ GetRedfishResourceConfig2Protocol (
       continue;
     }
 
-    if ((AsciiStrCmp (Schema->Schema, SchemaInfo.Schema) == 0) &&
-        (AsciiStrCmp (Schema->Major, SchemaInfo.Major) == 0) &&
-        (AsciiStrCmp (Schema->Minor, SchemaInfo.Minor) == 0) &&
-        (AsciiStrCmp (Schema->Errata, SchemaInfo.Errata) == 0))
-    {
+    if ((AsciiStrCmp (Schema->Schema, SchemaInfo.Schema) != 0)) {
+      continue;
+    }
+
+    //
+    // Compare schema version
+    //
+    SchemaVersionResult = CompareSchemaVersion (Schema, &SchemaInfo);
+    if (SchemaVersionResult == SCHEMA_COMPARE_ERROR) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a, compare schema error %a %a.%a.%a vs %a %a.%a.%a\n",
+        __func__,
+        Schema->Schema,
+        Schema->Major,
+        Schema->Minor,
+        Schema->Errata,
+        SchemaInfo.Schema,
+        SchemaInfo.Major,
+        SchemaInfo.Minor,
+        SchemaInfo.Errata
+        ));
+      continue;
+    }
+
+    if (SchemaVersionResult == SCHEMA_LEFT_EQUAL_TO_RIGHT) {
+      //
+      // Perfect match
+      //
       Found = TRUE;
       break;
+    } else {
+      if (!PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+        continue;
+      }
+
+      //
+      // Check to see if this schema version is Compatible or not.
+      // The rule is: we can use old schema version to support new schema version
+      // because old/deprecated attributes will still be in new schema version.
+      //
+      if (SchemaVersionResult == SCHEMA_LEFT_SMALLER_THAN_RIGHT) {
+        continue;
+      }
+
+      CompatibleHandle   = HandleBuffer[Index];
+      CompatibleProtocol = Protocol;
+      CopyMem (&CompatibleSchemaInfo, &SchemaInfo, sizeof (REDFISH_SCHEMA_INFO));
     }
   }
 
   if (Found) {
-    if (mRedfishResourceConfig2Cache != NULL) {
-      mRedfishResourceConfig2Cache->CachedHandle                          = HandleBuffer[Index];
-      mRedfishResourceConfig2Cache->RedfishResourceConfig.Config2Protocol = Protocol;
-      CopyMem (&mRedfishResourceConfig2Cache->SchemaInfoCache, Schema, sizeof (REDFISH_SCHEMA_INFO));
-    }
-
+    CacheConfigProtocol (mRedfishResourceConfig2Cache, HandleBuffer[Index], Protocol, Schema, FALSE, TRUE);
     if (Handle != NULL) {
       *Handle = HandleBuffer[Index];
     }
+  } else if (CompatibleHandle != NULL) {
+    DEBUG ((
+      DEBUG_WARN,
+      "Compatible mode enabled!! Select %a %a.%a.%a to support %a %a.%a.%a\n",
+      CompatibleSchemaInfo.Schema,
+      CompatibleSchemaInfo.Major,
+      CompatibleSchemaInfo.Minor,
+      CompatibleSchemaInfo.Errata,
+      Schema->Schema,
+      Schema->Major,
+      Schema->Minor,
+      Schema->Errata
+      ));
+
+    CacheConfigProtocol (mRedfishResourceConfig2Cache, CompatibleHandle, CompatibleProtocol, &CompatibleSchemaInfo, TRUE, TRUE);
+
+    if (Handle != NULL) {
+      *Handle = CompatibleHandle;
+    }
+
+    Found    = TRUE;
+    Protocol = CompatibleProtocol;
   }
 
   FreePool (HandleBuffer);

--- a/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.inf
+++ b/RedfishClientPkg/Library/EdkIIRedfishResourceConfigLib/EdkIIRedfishResourceConfigLib.inf
@@ -41,6 +41,7 @@
   RedfishFeatureUtilityLib
   RedfishPlatformConfigLib
   RedfishHttpLib
+  PrintLib
 
 [Protocols]
   gEdkIIRedfishResourceConfigProtocolGuid         ## CONSUMES ##
@@ -50,4 +51,4 @@
 [Pcd]
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
   gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
-
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport

--- a/RedfishClientPkg/RedfishClientPkg.dec
+++ b/RedfishClientPkg/RedfishClientPkg.dec
@@ -75,6 +75,8 @@
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishSystemRebootTimeout|5|UINT16|0x20000002
   ## Default capability of Redfish service side ETAG support
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishServiceEtagSupported|TRUE|BOOLEAN|0x10000005
+  # Support newer schema version by using old schema version driver.
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport|TRUE|BOOLEAN|0x10000006
 
 [PcdsDynamicEx]
   ## The flag used to indicate that system reboot is required due to system configuration change


### PR DESCRIPTION
# Description

### Problem statement
In current [EFI_REST_JSON_STRUCTURE_PROTOCOL design](https://uefi.org/specs/UEFI/2.10_A/31_EFI_Redfish_Service_Support.html#the-guidance-of-writing-efi-redfish-jsonstructure-converter), there is one-to-one mapping between Redfish schema version and Redfish feature driver. When BMC supports new Redfish schema version, the corresponding BIOS firmware update is required to include new feature driver. Otherwise, Redfish feature driver cannot find correct schema version support and entire UEFI Redfish function is failing. This creates trouble for firmware release management because BMC firmware and BIOS firmware are coupled together. And there is no guarantee that user will always update both two firmware together.

### Discussion
To decouple BMC firmware and BIOS firmware, we need a way to support newer Redfish schema version by using existing Redfish feature drivers. Redfish schema supports backward compatibility where deprecated attributes still stay in newer schema version (with "deprecated" and "versionDeprecated" presented). So, In theory, Redfish feature driver in old schema version can support newer schema version without problem.

### Solution
EdkIIRedfishResourceConfigLib is used to find correct schema version of feature driver. When there is no matched driver can be found in system, it tries to find "best match" schema version of feature driver. The rule is:

- Schema name must be the same
- When schema version of feature driver is smaller than requested schema version, this feature driver is selected.

After "best match" feature driver is found, feature driver will update schema version in JSON context so EFI_REST_JSON_STRUCTURE_PROTOCOL  can work. A PCD "PcdRedfishCompatibleSchemaSupport" is introduced to turn of compatibility support when user wants "perfect match" schema version support in system.

## How This Was Tested

- Build pass on RedfishClientPkg
- Tested on server platform
