### PR TITLE
RedfishClientPkg/RedfishFeatureCoreDxe: report failure via status code

### DIFF
--- a/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.h
+++ b/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.h
@@ -2,7 +2,7 @@
   Definitions of RedfishFeatureCoreDxe
 
   (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -24,6 +24,7 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/RedfishEventLib.h>
 #include <Library/RedfishFeatureUtilityLib.h>
+#include <Library/ReportStatusCodeLib.h>
 
 #define MaxNodeNameLength             64
 #define MaxParentUriLength            512
@@ -34,6 +35,9 @@
 #define NodeIsCollectionRightBracket  L'}'
 #define NodeIsCollectionSymbol        L"/{}"
 #define REDFISH_FEATURE_CORE_TPL      TPL_CALLBACK
+#define REDFISH_INTERNAL_ERROR        "Redfish service failure. Configuration at BMC may not be up-to-date."
+#define REDFISH_COMMUNICATION_ERROR   "Redfish communication failure. Configuration at BMC may not be up-to-date."
+#define REDFISH_CONFIG_CHANGED        "System configuration is changed from RESTful interface. System reboot."
 
 typedef struct _REDFISH_FEATURE_INTERNAL_DATA REDFISH_FEATURE_INTERNAL_DATA;
 struct _REDFISH_FEATURE_INTERNAL_DATA {

--- a/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.inf
+++ b/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.inf
@@ -4,7 +4,7 @@
 #  drivers for the registration.
 #
 #  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP<BR>
-#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -44,6 +44,7 @@
   UefiDriverEntryPoint
   UefiRuntimeServicesTableLib
   UefiLib
+  ReportStatusCodeLib
 
 [Protocols]
   gEdkIIRedfishFeatureProtocolGuid    ## BY_START


### PR DESCRIPTION
# Description

Manageability status code is introduced to edk2 (https://github.com/tianocore/edk2/pull/6560). Add the ability to report Redfish communication failure via status code. This gives the chance for BMC to capture Redfish error.

When system reboot is required to apply Redfish changes, we also report it via status code. So, user is aware of this reboot.

## How This Was Tested

- build pass
- tested on Arm based server
