### PR TITLE
RedfishClientPkg/RedfishFeatureUtilityLib: incorrect format type

### DIFF
--- a/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.c
+++ b/RedfishClientPkg/Library/RedfishFeatureUtilityLib/RedfishFeatureUtilityLib.c
@@ -453,7 +453,7 @@ ApplyFeatureSettingsStringType (
         //
         REDFISH_ENABLE_SYSTEM_REBOOT ();
       } else {
-        DEBUG ((DEBUG_ERROR, "%a: apply %s to %s failed: %r\n", __func__, ConfigureLang, FeatureValue, Status));
+        DEBUG ((DEBUG_ERROR, "%a: apply %s to %a failed: %r\n", __func__, ConfigureLang, FeatureValue, Status));
       }
     } else {
       DEBUG ((DEBUG_ERROR, "%a: %a.%a %s value is: %a\n", __func__, Schema, Version, ConfigureLang, RedfishValue.Value.Buffer));


### PR DESCRIPTION
# Description

Fix incorrect format type. FeatureValue is CHAR8 string and the format type is %a instead of %s.

## How This Was Tested

Build pass
