### PR TITLE
RedfishClientPkg: Fix to align string buffer

### DIFF
--- a/RedfishClientPkg/HiiToRedfishBiosDxe/HiiToRedfishBiosData.h
+++ b/RedfishClientPkg/HiiToRedfishBiosDxe/HiiToRedfishBiosData.h
@@ -31,8 +31,6 @@ extern EFI_GUID  gHiiToRedfishBiosFormsetGuid;
 #define ID_STRING_MAX                  15
 #define ID_STRING_MAX_WITH_TERMINATOR  16
 
-#pragma pack(1)
-
 //
 // Definiton of HII_TO_REDFISH_BIOS_VARSTORE_DATA
 //
@@ -44,5 +42,4 @@ typedef struct {
   UINT8     Reserved;
 } HII_TO_REDFISH_BIOS_EFI_VARSTORE_DATA;
 
-#pragma pack()
 #endif


### PR DESCRIPTION
# Description

StrCpyS resulting into crash because of  alignment issues, fixing this failure by removing #pragma pack(1) and use the default #pragma as per the build option, to align the string buffer to 16-bit boundary

Crash : ASSERT [HiiToRedfishBiosDxe] /edk2/MdePkg/Library/BaseLib/SafeString.c(234): ((UINTN)Destination & 0x00000001) == 0

## How This Was Tested

Build passed : RedfishClientPkg
Bootup passed : Qemu (ArmVirtPkg) with RedfishClientPkg
