### PR TITLE
RedfishClientPkg/RedfishFeatureCoreDxe: Limit Redfish Feature Driver Launches

### DIFF
--- a/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.c
+++ b/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.c
@@ -292,7 +292,7 @@ RedfishFeatureDriverStartup (
   // the Redfish operations.
   //
   if (ResourceUriNodeList == NULL) {
-    return;
+    goto Exit;
   }
 
   //
@@ -301,7 +301,7 @@ RedfishFeatureDriverStartup (
   mInformationExchange = (RESOURCE_INFORMATION_EXCHANGE *)AllocateZeroPool (sizeof (RESOURCE_INFORMATION_EXCHANGE));
   if (mInformationExchange == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Fail to allocate memory for exchange information.\n", __func__));
-    return;
+    goto Exit;
   }
 
   //
@@ -375,6 +375,12 @@ RedfishFeatureDriverStartup (
   // Restore to the TPL where this callback handler is called.
   //
   gBS->RaiseTPL (REDFISH_FEATURE_CORE_TPL);
+
+  Exit:
+  //
+  // Only launch Redfish feature core once.
+  //
+  gBS->CloseEvent (mEdkIIRedfishFeatureDriverStartupEvent);
 }
 
 /**


### PR DESCRIPTION
edk2 Redfish feature drivers are launched multiple times at BDS phase when the boot option attempt is failed. Redfish registers edk2 READY_TO_BOOT event to trigger edk2 Redfish processes; however, it is possible for the Redfish process to be triggered multiple times if
the boot option attempt fails. This fix limits Redfish feature code driver to only be launched once.

Cc: Abner Chang <abner.chang@amd.com>
Signed-off-by: Matthew Graham <Matthew.Graham@amd.com>

## How This Was Tested

Change was tested by AMD internal CI