### PR TITLE
RedfishClientPkg: Redfish feature driver BIOS v1.1.0

### DIFF
--- a/RedfishClientPkg/Features/Bios/v1_1_0/Common/BiosCommon.c
+++ b/RedfishClientPkg/Features/Bios/v1_1_0/Common/BiosCommon.c
@@ -1,0 +1,999 @@
+/** @file
+  Redfish feature driver implementation - common functions
+
+  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "BiosCommon.h"
+
+CHAR8  BiosEmptyJson[] = "{\"@odata.id\": \"\", \"@odata.type\": \"#Bios.v1_1_0.Bios\", \"Id\": \"\", \"Name\": \"\", \"Attributes\":{}}";
+
+REDFISH_RESOURCE_COMMON_PRIVATE  *mRedfishResourcePrivate             = NULL;
+EFI_HANDLE                       mRedfishResourceConfigProtocolHandle = NULL;
+REDFISH_SCHEMA_INFO              mSchemaInfo                          = {
+  { RESOURCE_SCHEMA        },
+  { RESOURCE_SCHEMA_MAJOR  },
+  { RESOURCE_SCHEMA_MINOR  },
+  { RESOURCE_SCHEMA_ERRATA }
+};
+
+/**
+  Consume resource from given URI.
+
+  @param[in]   This                Pointer to REDFISH_RESOURCE_COMMON_PRIVATE instance.
+  @param[in]   Json                The JSON to consume.
+  @param[in]   HeaderEtag          The Etag string returned in HTTP header.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishConsumeResourceCommon (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN  CHAR8                            *Json,
+  IN  CHAR8                            *HeaderEtag OPTIONAL
+  )
+{
+  EFI_STATUS                        Status;
+  EFI_REDFISH_BIOS_V1_1_0           *Bios;
+  EFI_REDFISH_BIOS_V1_1_0_CS        *BiosCs;
+  EFI_STRING                        ConfigureLang;
+  RedfishCS_Type_EmptyProp_CS_Data  *EmptyPropCs;
+  CHAR8                             *PatchedJson;
+
+  if ((Private == NULL) || IS_EMPTY_STRING (Json)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Bios          = NULL;
+  BiosCs        = NULL;
+  ConfigureLang = NULL;
+  PatchedJson   = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, Json, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
+  Status = Private->JsonStructProtocol->ToStructure (
+                                          Private->JsonStructProtocol,
+                                          NULL,
+                                          (PatchedJson == NULL ? Json : PatchedJson),
+                                          (EFI_REST_JSON_STRUCTURE_HEADER **)&Bios
+                                          );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: ToStructure() failed: %r\n", __func__, Status));
+    goto ON_RELEASE;
+  }
+
+  BiosCs = Bios->Bios;
+
+  //
+  // Check ETAG to see if we need to consume it
+  //
+  if (CheckEtag (Private->Uri, HeaderEtag, BiosCs->odata_etag)) {
+    //
+    // No change
+    //
+    DEBUG ((DEBUG_MANAGEABILITY, "%a: ETAG: %s has no change, ignore consume action\n", __func__, Private->Uri));
+    Status = EFI_SUCCESS;
+    goto ON_RELEASE;
+  }
+
+  //
+  // Handle ATTRIBUTES
+  //
+  if (BiosCs->Attributes == NULL) {
+    BiosCs->Attributes = AllocateZeroPool (sizeof (RedfishBios_V1_1_0_Attributes_CS));
+    ASSERT (BiosCs->Attributes != NULL);
+    // initialize list
+    BiosCs->Attributes->Prop.ForwardLink = &BiosCs->Attributes->Prop;
+  }
+
+  //
+  // Handle ATTRIBUTES->EmptyProperty
+  //
+  if (BiosCs->Attributes != NULL) {
+    //
+    // Validate empty property.
+    //
+    if (BiosCs->Attributes->Prop.ForwardLink == &BiosCs->Attributes->Prop) {
+      goto ON_RELEASE;
+    }
+
+    EmptyPropCs = (RedfishCS_Type_EmptyProp_CS_Data *)BiosCs->Attributes->Prop.ForwardLink;
+    if (EmptyPropCs->Header.ResourceType == RedfishCS_Type_JSON) {
+      DEBUG ((DEBUG_ERROR, "%a: Empty property with RedfishCS_Type_JSON type resource is not supported yet. (%s)\n", __func__, Private->Uri));
+      goto ON_RELEASE;
+    }
+
+    if (EmptyPropCs->NunmOfProperties > 0) {
+      //
+      // Find corresponding configure language for collection resource.
+      //
+      ConfigureLang = GetConfigureLang (BiosCs->odata_id, "Attributes");
+      if (ConfigureLang != NULL) {
+        DEBUG ((DEBUG_MANAGEABILITY, "%a: Configure language %s.\n", __func__, ConfigureLang));
+        Status = ApplyFeatureSettingsVagueType (RESOURCE_SCHEMA, RESOURCE_SCHEMA_VERSION, ConfigureLang, EmptyPropCs->KeyValuePtr, EmptyPropCs->NunmOfProperties);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "%a: apply setting for %s failed: %r\n", __func__, ConfigureLang, Status));
+        }
+
+        FreePool (ConfigureLang);
+      } else {
+        DEBUG ((DEBUG_ERROR, "%a: can not get configure language for URI: %s\n", __func__, Private->Uri));
+      }
+    }
+  }
+
+ON_RELEASE:
+
+  //
+  // Release resource.
+  //
+  if (Bios != NULL) {
+    Private->JsonStructProtocol->DestoryStructure (
+                                   Private->JsonStructProtocol,
+                                   (EFI_REST_JSON_STRUCTURE_HEADER *)Bios
+                                   );
+  }
+
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Provision the BIOS configurations.
+
+  @param[in]   JsonStructProtocol   Pointer to EFI_REST_JSON_STRUCTURE_PROTOCOL instance.
+  @param[in]   InputJson            The input JSON file
+  @param[in]   ResourceId           The Redfish resource ID.
+  @param[in]   ConfigureLang        ConfigureLang of BIOS configuration.
+  @param[in]   ProvisionMode        TRUE is provsion a new resource, FALSE means provision an exist resource.
+  @param[out]  ResultJson           The final BIOS Redfish resource to provision.
+
+  @retval EFI_SUCCESS               The final JSON of BIOS Redfish resource is returned.
+  @retval Others                    Some error happened.
+
+**/
+EFI_STATUS
+ProvisioningBiosProperties (
+  IN  EFI_REST_JSON_STRUCTURE_PROTOCOL  *JsonStructProtocol,
+  IN  CHAR8                             *InputJson,
+  IN  CHAR8                             *ResourceId OPTIONAL,
+  IN  EFI_STRING                        ConfigureLang,
+  IN  BOOLEAN                           ProvisionMode,
+  OUT CHAR8                             **ResultJson
+  )
+{
+  EFI_REDFISH_BIOS_V1_1_0       *Bios;
+  EFI_REDFISH_BIOS_V1_1_0_CS    *BiosCs;
+  EFI_REDFISH_BIOS_V1_1_0       *BiosEmpty;
+  EFI_REDFISH_BIOS_V1_1_0_CS    *BiosCsEmpty;
+  EFI_STATUS                    Status;
+  BOOLEAN                       PropertyChanged;
+  RedfishCS_EmptyProp_KeyValue  *PropertyVagueValues;
+  UINT32                        VagueValueNumber;
+  CHAR8                         *PatchedJson;
+
+  if ((JsonStructProtocol == NULL) || (ResultJson == NULL) || IS_EMPTY_STRING (InputJson) || IS_EMPTY_STRING (ConfigureLang)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: Provision for %s with: %s\n", __func__, ConfigureLang, (ProvisionMode ? L"Provision resource" : L"Update resource")));
+
+  *ResultJson     = NULL;
+  PropertyChanged = FALSE;
+  Bios            = NULL;
+  PatchedJson     = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, InputJson, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
+  Bios   = NULL;
+  Status = JsonStructProtocol->ToStructure (
+                                 JsonStructProtocol,
+                                 NULL,
+                                 (PatchedJson == NULL ? InputJson : PatchedJson),
+                                 (EFI_REST_JSON_STRUCTURE_HEADER **)&Bios
+                                 );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: ToStructure failure: %r\n", __func__, Status));
+    goto ON_RELEASE;
+  }
+
+  BiosEmpty = NULL;
+  Status    = JsonStructProtocol->ToStructure (
+                                    JsonStructProtocol,
+                                    NULL,
+                                    (PatchedJson == NULL ? BiosEmptyJson : PatchedJson),
+                                    (EFI_REST_JSON_STRUCTURE_HEADER **)&BiosEmpty
+                                    );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: ToStructure failure: %r\n", __func__, Status));
+    goto ON_RELEASE;
+  }
+
+  BiosCs = Bios->Bios;
+  //
+  // Initial an empty ComputerSystemCS
+  //
+  BiosCsEmpty = BiosEmpty->Bios;
+
+  //
+  // Handle ATTRIBUTES
+  //
+  if (BiosCs->Attributes != NULL) {
+    //
+    // Handle ATTRIBUTES
+    //
+    if (PropertyChecker (BiosCs->Attributes, ProvisionMode)) {
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: Getting platform configuration values of all x-UEFI-redfish configuration languages...\n", __func__));
+      PropertyVagueValues = GetPropertyVagueValue (RESOURCE_SCHEMA, RESOURCE_SCHEMA_VERSION, L"Attributes", ConfigureLang, &VagueValueNumber);
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: %d BIOS Configurations to compare (Provision mode: %s)\n", __func__, VagueValueNumber, ProvisionMode ? L"New" : L"Exist"));
+      if (PropertyVagueValues != NULL) {
+        if (ProvisionMode || !CompareRedfishPropertyVagueValues (
+                                ((RedfishCS_Type_EmptyProp_CS_Data *)BiosCs->Attributes->Prop.ForwardLink)->KeyValuePtr,
+                                ((RedfishCS_Type_EmptyProp_CS_Data *)BiosCs->Attributes->Prop.ForwardLink)->NunmOfProperties,
+                                PropertyVagueValues,
+                                VagueValueNumber
+                                ))
+        {
+          //
+          // Use the properties on system to replace the one on Redfish service.
+          //
+          ((RedfishCS_Type_EmptyProp_CS_Data *)BiosCsEmpty->Attributes->Prop.ForwardLink)->KeyValuePtr      = PropertyVagueValues;
+          ((RedfishCS_Type_EmptyProp_CS_Data *)BiosCsEmpty->Attributes->Prop.ForwardLink)->NunmOfProperties = VagueValueNumber;
+          PropertyChanged                                                                                   = TRUE;
+        }
+      }
+    }
+  }
+
+  //
+  // Convert C structure back to JSON text.
+  //
+  Status = JsonStructProtocol->ToJson (
+                                 JsonStructProtocol,
+                                 (EFI_REST_JSON_STRUCTURE_HEADER *)BiosEmpty,
+                                 ResultJson
+                                 );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: ToJson() failed: %r\n", __func__, Status));
+    goto ON_RELEASE;
+  }
+
+  if (PropertyChanged) {
+    //
+    // Remove Redfish unchangeable properties.
+    //
+    DEBUG ((
+      DEBUG_MANAGEABILITY,
+      "%a: PropertyChanged == TRUE, configuration is updated from BIOS or the Redfish pending setting that was just applied to BIOS.\n",
+      __func__
+      ));
+    Status = RedfishRemoveUnchangeableProperties (ResultJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Fail to remove Redfish unchangeable properties from ResultJson.\n", __func__));
+      *ResultJson = NULL;
+    }
+  }
+
+ON_RELEASE:
+  //
+  // Release resource.
+  //
+  if (Bios != NULL) {
+    JsonStructProtocol->DestoryStructure (
+                          JsonStructProtocol,
+                          (EFI_REST_JSON_STRUCTURE_HEADER *)Bios
+                          );
+  }
+
+  JsonStructProtocol->DestoryStructure (
+                        JsonStructProtocol,
+                        (EFI_REST_JSON_STRUCTURE_HEADER *)BiosEmpty
+                        );
+
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+  }
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return (PropertyChanged ? EFI_SUCCESS : EFI_NOT_FOUND);
+}
+
+/**
+  Provisioning the refresh new BIOS Redfish resource for one configuration language.
+
+  @param[in]   Private             Pointer to REDFISH_RESOURCE_COMMON_PRIVATE.
+  @param[in]   Index               ConfigureLang index.
+  @param[in]   ConfigureLang       ConfigureLang string.
+
+  @retval EFI_SUCCESS              BIOS Redfish resource is provisioned sucessfully.
+  @retval Others                   Some error happen.
+
+**/
+EFI_STATUS
+ProvisioningBiosResource (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN  UINTN                            Index,
+  IN  EFI_STRING                       ConfigureLang
+  )
+{
+  CHAR8             *Json;
+  CHAR8             *JsonWithAddendum;
+  EFI_STATUS        Status;
+  EFI_STRING        NewResourceLocation;
+  CHAR8             ResourceId[16];
+  REDFISH_RESPONSE  Response;
+
+  if (IS_EMPTY_STRING (ConfigureLang) || (Private == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&Response, sizeof (REDFISH_RESPONSE));
+  AsciiSPrint (ResourceId, sizeof (ResourceId), "%d", Index);
+
+  NewResourceLocation = NULL;
+
+  Status = ProvisioningBiosProperties (
+             Private->JsonStructProtocol,
+             BiosEmptyJson,
+             ResourceId,
+             ConfigureLang,
+             TRUE,
+             &Json
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: provisioning resource for %s failed: %r\n", __func__, ConfigureLang, Status));
+    return Status;
+  }
+
+  //
+  // Check and see if platform has OEM data or not
+  //
+  Status = RedfishGetOemData (
+             Private->Uri,
+             RESOURCE_SCHEMA,
+             RESOURCE_SCHEMA_VERSION,
+             Json,
+             &JsonWithAddendum
+             );
+  if (!EFI_ERROR (Status) && (JsonWithAddendum != NULL)) {
+    FreePool (Json);
+    Json             = JsonWithAddendum;
+    JsonWithAddendum = NULL;
+  }
+
+  //
+  // Check and see if platform has addendum data or not
+  //
+  Status = RedfishGetAddendumData (
+             Private->Uri,
+             RESOURCE_SCHEMA,
+             RESOURCE_SCHEMA_VERSION,
+             Json,
+             &JsonWithAddendum
+             );
+  if (!EFI_ERROR (Status) && (JsonWithAddendum != NULL)) {
+    FreePool (Json);
+    Json             = JsonWithAddendum;
+    JsonWithAddendum = NULL;
+  }
+
+  Status = RedfishHttpPostResource (Private->RedfishService, Private->Uri, Json, &Response);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: post Bios resource for %s failed: %r\n", __func__, ConfigureLang, Status));
+    goto RELEASE_RESOURCE;
+  }
+
+  //
+  // Per Redfish spec. the URL of new resource will be returned in "Location" header.
+  //
+  Status = GetHttpResponseLocation (&Response, &NewResourceLocation);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: cannot find new location: %r\n", __func__, Status));
+    goto RELEASE_RESOURCE;
+  }
+
+  //
+  // Keep location of new resource.
+  //
+  if (NewResourceLocation != NULL) {
+    DEBUG ((DEBUG_MANAGEABILITY, "%a: Location: %s\n", __func__, NewResourceLocation));
+    RedfishSetRedfishUri (ConfigureLang, NewResourceLocation);
+  }
+
+RELEASE_RESOURCE:
+
+  if (NewResourceLocation != NULL) {
+    FreePool (NewResourceLocation);
+  }
+
+  if (Json != NULL) {
+    FreePool (Json);
+  }
+
+  RedfishHttpFreeResponse (&Response);
+
+  return Status;
+}
+
+/**
+  Provisioning the refresh new BIOS Redfish resource according to the configuration languages.
+
+  @param[in]   Private             Pointer to REDFISH_RESOURCE_COMMON_PRIVATE.
+                                   FALSE if resource does not exist POST method is used.
+
+  @retval EFI_SUCCESS              BIOS Redfish resource is provisioned sucessfully.
+          EFI_NOT_FOUND            No need to provision BIOS Redfish resource as
+                                   there is no BIOS configuration is managed by Redfish.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+ProvisioningBiosResources (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private
+  )
+{
+  REDFISH_FEATURE_ARRAY_TYPE_CONFIG_LANG  ConfigureLangArray;
+
+  if (Private == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ConfigureLangArray.Index         = 1;
+  ConfigureLangArray.ConfigureLang = RedfishGetConfigLanguage (Private->Uri);
+  if (ConfigureLangArray.ConfigureLang == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: Create BIOS resource from ConfigureLang: %s\n", __func__, ConfigureLangArray.ConfigureLang));
+
+  ProvisioningBiosResource (Private, ConfigureLangArray.Index, ConfigureLangArray.ConfigureLang);
+  FreePool (ConfigureLangArray.ConfigureLang);
+  return EFI_SUCCESS;
+}
+
+/**
+  Provisioning the existing BIOS Redfish resource.
+
+  @param[in]   Private             Pointer to REDFISH_RESOURCE_COMMON_PRIVATE.
+                                   FALSE if resource does not exist POST method is used.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+ProvisioningBiosExistResource (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private
+  )
+{
+  EFI_STATUS        Status;
+  EFI_STRING        ConfigureLang;
+  CHAR8             *Json;
+  CHAR8             *JsonWithAddendum;
+  REDFISH_RESPONSE  Response;
+
+  if (Private == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Json          = NULL;
+  ConfigureLang = NULL;
+  ZeroMem (&Response, sizeof (REDFISH_RESPONSE));
+
+  ConfigureLang = RedfishGetConfigLanguage (Private->Uri);
+  if (ConfigureLang == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  DEBUG ((DEBUG_ERROR, "%a: provisioning existing resource for %s.\n", __func__, ConfigureLang));
+  Status = ProvisioningBiosProperties (
+             Private->JsonStructProtocol,
+             BiosEmptyJson,
+             NULL,
+             ConfigureLang,
+             TRUE,
+             &Json
+             );
+  if (EFI_ERROR (Status)) {
+    if (Status == EFI_NOT_FOUND) {
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: provisioning existing resource for %s ignored. Nothing changed\n", __func__, ConfigureLang));
+      Status = EFI_SUCCESS;
+    } else {
+      DEBUG ((DEBUG_ERROR, "%a: provisioning existing resource for %s failed: %r\n", __func__, ConfigureLang, Status));
+    }
+
+    goto ON_RELEASE;
+  }
+
+  //
+  // Check and see if platform has OEM data or not
+  //
+  Status = RedfishGetOemData (
+             Private->Uri,
+             RESOURCE_SCHEMA,
+             RESOURCE_SCHEMA_VERSION,
+             Json,
+             &JsonWithAddendum
+             );
+  if (!EFI_ERROR (Status) && (JsonWithAddendum != NULL)) {
+    FreePool (Json);
+    Json             = JsonWithAddendum;
+    JsonWithAddendum = NULL;
+  }
+
+  //
+  // Check and see if platform has addendum data or not
+  //
+  Status = RedfishGetAddendumData (
+             Private->Uri,
+             RESOURCE_SCHEMA,
+             RESOURCE_SCHEMA_VERSION,
+             Json,
+             &JsonWithAddendum
+             );
+  if (!EFI_ERROR (Status) && (JsonWithAddendum != NULL)) {
+    FreePool (Json);
+    Json             = JsonWithAddendum;
+    JsonWithAddendum = NULL;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: provisioning existing resource for %s\n", __func__, ConfigureLang));
+
+  //
+  // PATCH the resource.
+  //
+  Status = RedfishHttpPatchResource (Private->RedfishService, Private->Uri, Json, &Response);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: patch resource for %s failed: %r\n", __func__, ConfigureLang, Status));
+  }
+
+ON_RELEASE:
+
+  RedfishHttpFreeResponse (&Response);
+
+  if (Json != NULL) {
+    FreePool (Json);
+  }
+
+  if (ConfigureLang != NULL) {
+    FreePool (ConfigureLang);
+  }
+
+  return Status;
+}
+
+/**
+  Provisioning redfish resource by given URI.
+
+  @param[in]   This                Pointer to EFI_HP_REDFISH_HII_PROTOCOL instance.
+  @param[in]   ResourceExist       TRUE if resource exists, PUT method will be used.
+                                   FALSE if resource does not exist POST method is used.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishProvisioningResourceCommon (
+  IN     REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN     BOOLEAN                          ResourceExist
+  )
+{
+  if (Private == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return (ResourceExist ? ProvisioningBiosExistResource (Private) : ProvisioningBiosResources (Private));
+}
+
+/**
+  Check resource from given URI.
+
+  @param[in]   This                Pointer to REDFISH_RESOURCE_COMMON_PRIVATE instance.
+  @param[in]   Json                The JSON to consume.
+  @param[in]   HeaderEtag          The Etag string returned in HTTP header.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishCheckResourceCommon (
+  IN     REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN     CHAR8                            *Json,
+  IN     CHAR8                            *HeaderEtag OPTIONAL
+  )
+{
+  UINTN       Index;
+  EFI_STATUS  Status;
+  EFI_STRING  *ConfigureLangList;
+  UINTN       Count;
+  EFI_STRING  Property;
+
+  if ((Private == NULL) || IS_EMPTY_STRING (Json)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Check ETAG to see if we need to check this resource again or not.
+  //
+  if (CheckEtag (Private->Uri, HeaderEtag, NULL)) {
+    //
+    // No change
+    //
+    DEBUG ((DEBUG_MANAGEABILITY, "%a: ETAG: %s has no change, ignore check action\n", __func__, Private->Uri));
+    return EFI_SUCCESS;
+  }
+
+  Status = RedfishPlatformConfigGetConfigureLang (RESOURCE_SCHEMA, RESOURCE_SCHEMA_VERSION, CONFIG_LANG_ARRAY_PATTERN, &ConfigureLangList, &Count);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: RedfishPlatformConfigGetConfigureLang failed: %r\n", __func__, Status));
+    return Status;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: Total configure language %d\n", __func__, Count));
+  if (Count == 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Status = EFI_NOT_FOUND;
+  for (Index = 0; Index < Count; Index++) {
+    Property = GetPropertyFromConfigureLang (Private->Uri, ConfigureLangList[Index]);
+    if (Property == NULL) {
+      continue;
+    }
+
+    if (MatchPropertyWithJsonContext (Property, Json)) {
+      //
+      // When there is any attribute found in /Bios/Attributes, it means that
+      // the provisioning was performed before. Any missing attribute will
+      // be handled by update operation.
+      // When all attributes are missing in /Bios/Attributes, provisioning is
+      // performed.
+      //
+      Status = EFI_SUCCESS;
+    }
+  }
+
+  if (Status == EFI_NOT_FOUND) {
+    DEBUG ((DEBUG_MANAGEABILITY, "%a, None of the BIOS property is found, we will provision it.\n", __func__));
+  }
+
+  FreePool (ConfigureLangList);
+  return Status;
+}
+
+/**
+  Update resource to given URI.
+
+  @param[in]   This                Pointer to REDFISH_RESOURCE_COMMON_PRIVATE instance.
+  @param[in]   Json                The JSON to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishUpdateResourceCommon (
+  IN     REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN     CHAR8                            *InputJson
+  )
+{
+  EFI_STATUS        Status;
+  CHAR8             *Json;
+  CHAR8             *JsonWithAddendum;
+  EFI_STRING        ConfigureLang;
+  REDFISH_RESPONSE  Response;
+
+  if ((Private == NULL) || IS_EMPTY_STRING (InputJson)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Json          = NULL;
+  ConfigureLang = NULL;
+  ZeroMem (&Response, sizeof (REDFISH_RESPONSE));
+
+  ConfigureLang = RedfishGetConfigLanguage (Private->Uri);
+  if (ConfigureLang == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  Status = ProvisioningBiosProperties (
+             Private->JsonStructProtocol,
+             InputJson,
+             NULL,
+             ConfigureLang,
+             FALSE,
+             &Json
+             );
+  if (EFI_ERROR (Status)) {
+    if (Status == EFI_NOT_FOUND) {
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: update resource for %s ignored. Nothing changed\n", __func__, ConfigureLang));
+      Status = EFI_SUCCESS;
+    } else {
+      DEBUG ((DEBUG_ERROR, "%a: update resource for %s failed: %r\n", __func__, ConfigureLang, Status));
+    }
+
+    goto ON_RELEASE;
+  }
+
+  //
+  // Check and see if platform has OEM data or not
+  //
+  Status = RedfishGetOemData (
+             Private->Uri,
+             RESOURCE_SCHEMA,
+             RESOURCE_SCHEMA_VERSION,
+             Json,
+             &JsonWithAddendum
+             );
+  if (!EFI_ERROR (Status) && (JsonWithAddendum != NULL)) {
+    FreePool (Json);
+    Json             = JsonWithAddendum;
+    JsonWithAddendum = NULL;
+  }
+
+  //
+  // Check and see if platform has addendum data or not
+  //
+  Status = RedfishGetAddendumData (
+             Private->Uri,
+             RESOURCE_SCHEMA,
+             RESOURCE_SCHEMA_VERSION,
+             Json,
+             &JsonWithAddendum
+             );
+  if (!EFI_ERROR (Status) && (JsonWithAddendum != NULL)) {
+    FreePool (Json);
+    Json             = JsonWithAddendum;
+    JsonWithAddendum = NULL;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: update resource for %s\n", __func__, ConfigureLang));
+
+  //
+  // PUT back to Redfish BIOS resource.
+  // We can't use PATCH here because PATCH to BIOS Redfish resource
+  // put the changes on BIOS/SD.
+  //
+  Status = RedfishHttpPutResource (Private->RedfishService, Private->Uri, Json, &Response);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: HTTP PUT resource for %s failed: %r\n", __func__, ConfigureLang, Status));
+  }
+
+ON_RELEASE:
+
+  RedfishHttpFreeResponse (&Response);
+
+  if (Json != NULL) {
+    FreePool (Json);
+  }
+
+  if (ConfigureLang != NULL) {
+    FreePool (ConfigureLang);
+  }
+
+  return Status;
+}
+
+/**
+  Identify resource from given URI.
+
+  @param[in]   This                Pointer to REDFISH_RESOURCE_COMMON_PRIVATE instance.
+  @param[in]   Json                The JSON to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishIdentifyResourceCommon (
+  IN     REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN     CHAR8                            *Json
+  )
+{
+  BOOLEAN                                      Supported;
+  EFI_STATUS                                   Status;
+  EFI_STRING                                   EndOfChar;
+  REDFISH_FEATURE_ARRAY_TYPE_CONFIG_LANG_LIST  ConfigLangList;
+  CHAR8                                        *PatchedJson;
+
+  PatchedJson = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, Json, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
+  Supported = RedfishIdentifyResource (Private->Uri, (PatchedJson == NULL ? Json : PatchedJson));
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+    PatchedJson = NULL;
+  }
+
+  if (Supported) {
+    Status = RedfishFeatureGetUnifiedArrayTypeConfigureLang (RESOURCE_SCHEMA, RESOURCE_SCHEMA_VERSION, CONFIG_LANG_ARRAY_PATTERN, &ConfigLangList);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: RedfishFeatureGetUnifiedArrayTypeConfigureLang failed: %r\n", __func__, Status));
+      return Status;
+    }
+
+    if (ConfigLangList.Count == 0) {
+      return EFI_SUCCESS;
+    }
+
+    // EndOfChar = StrStr (ConfigLangList.List[0].ConfigureLang, L"}");
+    Status = IsConfigLangArray (ConfigLangList.List[0].ConfigureLang, NULL, &EndOfChar);
+    if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+      ASSERT (FALSE);
+      return EFI_DEVICE_ERROR;
+    }
+
+    if (Status != EFI_SUCCESS) {
+      //
+      // This is not the collection config language.
+      //
+      GetConfigLangNodeByIndex (ConfigLangList.List[0].ConfigureLang, 0, &EndOfChar);
+    }
+
+    *(++EndOfChar) = '\0';
+    //
+    // Keep URI and ConfigLang mapping
+    //
+    RedfishSetRedfishUri (ConfigLangList.List[0].ConfigureLang, Private->Uri);
+    //
+    // Set the configuration language in the RESOURCE_INFORMATION_EXCHANGE.
+    // This information is sent back to the parent resource (e.g. the collection driver).
+    //
+    EdkIIRedfishResourceSetConfigureLang (mRedfishResourceConfigProtocolHandle, &ConfigLangList);
+    DestroyConfiglanguageList (&ConfigLangList);
+    return EFI_SUCCESS;
+  }
+
+  return EFI_UNSUPPORTED;
+}
+
+EFI_STATUS
+HandleResource (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN  EFI_STRING                       Uri
+  )
+{
+  EFI_STATUS           Status;
+  REDFISH_SCHEMA_INFO  SchemaInfo;
+  EFI_STRING           ConfigLang;
+  BOOLEAN              SystemResetDetected;
+
+  if ((Private == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Resource matching.
+  //
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: process resource for: %s\n", __func__, Uri));
+
+  Status = GetRedfishSchemaInfo (Private->RedfishService, Private->JsonStructProtocol, Uri, NULL, &SchemaInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to get schema information from: %s %r\n", __func__, Uri, Status));
+    return Status;
+  }
+
+  //
+  // Check and see if this is target resource that we want to handle.
+  // Some resource is handled by other provider so we have to make sure this first.
+  //
+  DEBUG ((DEBUG_MANAGEABILITY, "%s Identify for %s\n", __func__, Uri));
+  SystemResetDetected = FALSE;
+  ConfigLang          = RedfishGetConfigLanguage (Uri);
+  if (ConfigLang == NULL) {
+    Status = EdkIIRedfishResourceConfigIdentify (&SchemaInfo, Uri, NULL, Private->InformationExchange);
+    if (EFI_ERROR (Status)) {
+      if (Status == EFI_UNSUPPORTED) {
+        DEBUG ((DEBUG_MANAGEABILITY, "%a: \"%s\" is not handled by us\n", __func__, Uri));
+        return EFI_SUCCESS;
+      } else if (Status == EFI_NOT_FOUND) {
+        DEBUG ((DEBUG_MANAGEABILITY, "%a, \"%s\" has nothing to handle\n", __func__, Uri));
+        return EFI_SUCCESS;
+      }
+
+      DEBUG ((DEBUG_ERROR, "%a: fail to identify resource: \"%s\": %r\n", __func__, Uri, Status));
+      return Status;
+    }
+
+    //
+    // When there is no history record in UEFI variable, this is first boot or
+    // system is reset by defaulting command. The pending setting on BMC may be
+    // a stale value so we will ignore pending settings in BMC.
+    //
+    SystemResetDetected = TRUE;
+  } else {
+    DEBUG ((REDFISH_DEBUG_TRACE, "%a: history record found: %s\n", __func__, ConfigLang));
+    FreePool (ConfigLang);
+  }
+
+  //
+  // Check and see if target property exist or not even when collection member exists.
+  // If not, we still do provision.
+  //
+  DEBUG ((REDFISH_DEBUG_TRACE, "%a: Check for %s\n", __func__, Uri));
+  Status = EdkIIRedfishResourceConfigCheck (&SchemaInfo, Uri, NULL);
+  if (EFI_ERROR (Status)) {
+    if (Status == EFI_UNSUPPORTED) {
+      DEBUG ((REDFISH_DEBUG_TRACE, "%a: \"%s\" has no attribute that is handled by us\n", __func__, Uri));
+      return EFI_SUCCESS;
+    }
+
+    if (Status == EFI_NOT_FOUND) {
+      //
+      // The target property does not exist, do the provision to create property.
+      //
+      DEBUG ((REDFISH_DEBUG_TRACE, "%a: None of properties are exist, full provision the resource for %s.\n", __func__, Uri));
+      Status = EdkIIRedfishResourceConfigProvisioning (&SchemaInfo, Uri, NULL, Private->InformationExchange, TRUE);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Failed to provision %r.\n", __func__, Status));
+        return Status;
+      }
+
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: Process resource for: %s finished.\n", __func__, Uri));
+    } else {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to check the resource on %s %r.\n", __func__, Uri, Status));
+      return Status;
+    }
+  }
+
+  //
+  // Consume first.
+  //
+  if (SystemResetDetected) {
+    DEBUG ((DEBUG_MANAGEABILITY, "%a: System has been reset to the default setting. Ignore the pending settings and don't consume it because they may be the stale values.\n", __func__));
+    DEBUG ((DEBUG_MANAGEABILITY, "%a: Skip the consume porcess.\n", __func__));
+  } else {
+    DEBUG ((DEBUG_MANAGEABILITY, "%a: Consume for %s\n", __func__, Uri));
+    Status = EdkIIRedfishResourceConfigConsume (&SchemaInfo, Uri, NULL);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to consume resource for: %s: %r\n", __func__, Uri, Status));
+    }
+  }
+
+  //
+  // Patch it.
+  //
+  DEBUG ((REDFISH_DEBUG_TRACE, "%a Update for %s\n", __func__, Uri));
+  Status = EdkIIRedfishResourceConfigUpdate (&SchemaInfo, Uri, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to update resource for: %s: %r\n", __func__, Uri, Status));
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: Process resource for: %s finished\n", __func__, Uri));
+
+  return Status;
+}

--- a/RedfishClientPkg/Features/Bios/v1_1_0/Common/BiosCommon.h
+++ b/RedfishClientPkg/Features/Bios/v1_1_0/Common/BiosCommon.h
@@ -1,0 +1,30 @@
+/** @file
+
+  Redfish feature driver implementation - internal header file
+  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef EFI_REDFISH_BIOS_COMMON_H_
+#define EFI_REDFISH_BIOS_COMMON_H_
+
+#include <RedfishJsonStructure/Bios/v1_1_0/EfiBiosV1_1_0.h>
+#include <RedfishResourceCommon.h>
+
+//
+// Schema information.
+//
+#define REDFISH_MANAGED_URI        L"Systems/{}/Bios"
+#define MAX_URI_LENGTH             256
+#define RESOURCE_SCHEMA            "Bios"
+#define RESOURCE_SCHEMA_MAJOR      "1"
+#define RESOURCE_SCHEMA_MINOR      "1"
+#define RESOURCE_SCHEMA_ERRATA     "0"
+#define RESOURCE_SCHEMA_VERSION    "v1_1_0"
+#define CONFIG_LANG_ARRAY_PATTERN  L"/Bios/.*"
+#define CONFIG_LANG_ARRAY_PREFIX   L"/Bios/"
+#define RESOURCE_SCHEMA_FULL       "x-UEFI-redfish-Bios.v1_1_0"
+
+#endif

--- a/RedfishClientPkg/Features/Bios/v1_1_0/Dxe/BiosDxe.c
+++ b/RedfishClientPkg/Features/Bios/v1_1_0/Dxe/BiosDxe.c
@@ -1,0 +1,827 @@
+/** @file
+  Redfish feature driver implementation - Bios
+
+  (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "../Common/BiosCommon.h"
+
+extern REDFISH_RESOURCE_COMMON_PRIVATE  *mRedfishResourcePrivate;
+extern EFI_HANDLE                       mRedfishResourceConfigProtocolHandle;
+
+EFI_STATUS
+HandleResource (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN  EFI_STRING                       Uri
+  );
+
+/**
+  Provisioning redfish resource by given URI.
+
+  @param[in]   This                Pointer to EFI_HP_REDFISH_HII_PROTOCOL instance.
+  @param[in]   Uri                 Target URI to create resource.
+  @param[in]   PostMode            TRUE if the resource does not exist, post method is used.
+                                   FALSE if the resource exist but property is missing, put method is used.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceProvisioningResource (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri,
+  IN     BOOLEAN                                 PostMode
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+  EFI_STATUS                       Status;
+  REDFISH_RESPONSE                 Response;
+
+  if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a: provisioning in %s mode\n", __func__, (PostMode ? L"POST" : L"PATCH")));
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
+  if (Private->RedfishService == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, NULL, &Response, TRUE);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: get resource from: %s failed\n", __func__, Uri));
+    return Status;
+  }
+
+  Private->Uri     = Uri;
+  Private->Payload = Response.Payload;
+  ASSERT (Private->Payload != NULL);
+
+  Status = RedfishProvisioningResourceCommon (Private, !PostMode);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to provision resource to: %s: %r\n", __func__, Uri, Status));
+  } else {
+    //
+    // Get latest ETag on URI and keep it in variable.
+    //
+    SetEtagFromUri (Private->RedfishService, Private->Uri, TRUE);
+  }
+
+  //
+  // Release resource
+  //
+  RedfishHttpFreeResponse (&Response);
+  Private->Payload = NULL;
+
+  return Status;
+}
+
+/**
+  Consume resource from given URI.
+
+  @param[in]   This                Pointer to EFI_HP_REDFISH_HII_PROTOCOL instance.
+  @param[in]   Uri                 The target URI to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceConsumeResource (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+  EFI_STATUS                       Status;
+  REDFISH_RESPONSE                 Response;
+  EFI_STRING                       PendingSettingUri;
+  REDFISH_RESPONSE                 PendingSettingResponse;
+  REDFISH_RESPONSE                 *ExpectedResponse;
+  CHAR8                            *Etag;
+
+  if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
+  if (Private->RedfishService == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, NULL, &Response, TRUE);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: get resource from: %s failed\n", __func__, Uri));
+    return Status;
+  }
+
+  //
+  // Check and see if "@Redfish.Settings" exist or not.
+  //
+  ZeroMem (&PendingSettingResponse, sizeof (PendingSettingResponse));
+  PendingSettingUri = NULL;
+  Status            = GetPendingSettings (
+                        Private->RedfishService,
+                        Response.Payload,
+                        &PendingSettingResponse,
+                        &PendingSettingUri
+                        );
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_MANAGEABILITY, "%a: @Redfish.Settings found: %s\n", __func__, PendingSettingUri));
+    SetRedfishSettingsObjectsUri (Uri, PendingSettingUri);
+    Private->Uri     = PendingSettingUri;
+    ExpectedResponse = &PendingSettingResponse;
+  } else {
+    DEBUG ((DEBUG_MANAGEABILITY, "%a: No @Redfish.Settings is found\n", __func__));
+    Private->Uri     = Uri;
+    ExpectedResponse = &Response;
+  }
+
+  Private->Payload = ExpectedResponse->Payload;
+  ASSERT (Private->Payload != NULL);
+
+  Private->Json = JsonDumpString (RedfishJsonInPayload (Private->Payload), EDKII_JSON_COMPACT);
+  ASSERT (Private->Json != NULL);
+
+  //
+  // Find etag in HTTP response header
+  //
+  Etag   = NULL;
+  Status = GetHttpResponseEtag (ExpectedResponse, &Etag);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, failed to get ETag from HTTP header\n", __func__));
+  }
+
+  Status = RedfishConsumeResourceCommon (Private, Private->Json, Etag);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to consume resource from: %s: %r\n", __func__, Private->Uri, Status));
+  }
+
+  // Release the resource of HTTP GET eariler.
+  RedfishHttpFreeResponse (&Response);
+
+  if (PendingSettingUri != NULL) {
+    // Delete the settings URI to indicate BIOS already consumed the change.
+    DEBUG ((DEBUG_INFO, "%a: Delete the resource on URI: %s:\n", __func__, Private->Uri));
+    Status = RedfishHttpDeleteResource (Private->RedfishService, Private->Uri, &Response);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to delete the resource on URI (BMC may not implemented the DELETE on URI): %s: %r\n", __func__, Private->Uri, Status));
+    }
+  }
+
+  //
+  // Release resource
+  //
+  RedfishHttpFreeResponse (&Response);
+  RedfishHttpFreeResponse (&PendingSettingResponse);
+  Private->Payload = NULL;
+
+  if (Private->Json != NULL) {
+    FreePool (Private->Json);
+    Private->Json = NULL;
+  }
+
+  if (Etag != NULL) {
+    FreePool (Etag);
+  }
+
+  if (PendingSettingUri != NULL) {
+    FreePool (PendingSettingUri);
+  }
+
+  return Status;
+}
+
+/**
+  Get information about this protocol.
+
+  @param[in]   This                Pointer to EFI_HP_REDFISH_HII_PROTOCOL instance.
+  @param[out]  Schema              Supported schema.
+  @param[out]  Major               Supported major number.
+  @param[out]  Minor               Supported minor number.
+  @param[out]  Errata              Supported errata number.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceGetInfo (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  OUT    REDFISH_SCHEMA_INFO                     *Info
+  )
+{
+  if ((This == NULL) || (Info == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  AsciiStrCpyS (Info->Schema, REDFISH_SCHEMA_STRING_SIZE, RESOURCE_SCHEMA);
+  AsciiStrCpyS (Info->Major, REDFISH_SCHEMA_VERSION_SIZE, RESOURCE_SCHEMA_MAJOR);
+  AsciiStrCpyS (Info->Minor, REDFISH_SCHEMA_VERSION_SIZE, RESOURCE_SCHEMA_MINOR);
+  AsciiStrCpyS (Info->Errata, REDFISH_SCHEMA_VERSION_SIZE, RESOURCE_SCHEMA_ERRATA);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Update resource to given URI.
+
+  @param[in]   This                Pointer to EFI_HP_REDFISH_HII_PROTOCOL instance.
+  @param[in]   Uri                 The target URI to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceUpdate (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+  EFI_STATUS                       Status;
+  REDFISH_RESPONSE                 Response;
+
+  if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
+
+  if (Private->RedfishService == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, NULL, &Response, TRUE);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: get resource from: %s failed\n", __func__, Uri));
+    return Status;
+  }
+
+  Private->Uri     = Uri;
+  Private->Payload = Response.Payload;
+  ASSERT (Private->Payload != NULL);
+
+  Private->Json = JsonDumpString (RedfishJsonInPayload (Private->Payload), EDKII_JSON_COMPACT);
+  ASSERT (Private->Json != NULL);
+
+  Status = RedfishUpdateResourceCommon (Private, Private->Json);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to update resource to: %s: %r\n", __func__, Uri, Status));
+  } else {
+    //
+    // Get latest ETag on URI and keep it in variable.
+    //
+    SetEtagFromUri (Private->RedfishService, Private->Uri, TRUE);
+  }
+
+  //
+  // Release resource
+  //
+  RedfishHttpFreeResponse (&Response);
+  Private->Payload = NULL;
+
+  if (Private->Json != NULL) {
+    FreePool (Private->Json);
+    Private->Json = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Check resource on given URI.
+
+  @param[in]   This                Pointer to EFI_HP_REDFISH_HII_PROTOCOL instance.
+  @param[in]   Uri                 The target URI to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceCheck (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+  EFI_STATUS                       Status;
+  REDFISH_RESPONSE                 Response;
+  CHAR8                            *Etag;
+
+  if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
+
+  if (Private->RedfishService == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, NULL, &Response, TRUE);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: get resource from: %s failed\n", __func__, Uri));
+    return Status;
+  }
+
+  Private->Uri     = Uri;
+  Private->Payload = Response.Payload;
+  ASSERT (Private->Payload != NULL);
+
+  Private->Json = JsonDumpString (RedfishJsonInPayload (Private->Payload), EDKII_JSON_COMPACT);
+  ASSERT (Private->Json != NULL);
+
+  //
+  // Find etag in HTTP response header
+  //
+  Etag   = NULL;
+  Status = GetHttpResponseEtag (&Response, &Etag);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, failed to get ETag from HTTP header\n", __func__));
+  }
+
+  Status = RedfishCheckResourceCommon (Private, Private->Json, Etag);
+  if (EFI_ERROR (Status)) {
+    if (Status == EFI_UNSUPPORTED) {
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: No BIOS configuration needs to be handled.\n", __func__));
+    } else if (Status == EFI_NOT_FOUND) {
+      DEBUG ((DEBUG_MANAGEABILITY, "%a: No BIOS property on Redfish service is found, we need to provision it.\n", __func__));
+    } else {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to check resource from: %s, some of properties may not provisioned to Redfish yet.\n", __func__, Uri));
+    }
+  }
+
+  //
+  // Release resource
+  //
+  if (Etag != NULL) {
+    FreePool (Etag);
+  }
+
+  RedfishHttpFreeResponse (&Response);
+  Private->Payload = NULL;
+
+  if (Private->Json != NULL) {
+    FreePool (Private->Json);
+    Private->Json = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Identify resource on given URI.
+
+  @param[in]   This                Pointer to EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL instance.
+  @param[in]   Uri                 The target URI to consume.
+
+  @retval EFI_SUCCESS              This is target resource which we want to handle.
+  @retval EFI_UNSUPPORTED          This is not the target resource.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceIdentify (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+  EFI_STATUS                       Status;
+  REDFISH_RESPONSE                 Response;
+
+  if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
+
+  if (Private->RedfishService == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, NULL, &Response, TRUE);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: get resource from: %s failed\n", __func__, Uri));
+    return Status;
+  }
+
+  Private->Uri     = Uri;
+  Private->Payload = Response.Payload;
+  ASSERT (Private->Payload != NULL);
+
+  Private->Json = JsonDumpString (RedfishJsonInPayload (Private->Payload), EDKII_JSON_COMPACT);
+  ASSERT (Private->Json != NULL);
+
+  Status = RedfishIdentifyResourceCommon (Private, Private->Json);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: identify %s failed: %r\n", __func__, Uri, Status));
+  }
+
+  //
+  // Release resource
+  //
+  RedfishHttpFreeResponse (&Response);
+  Private->Payload = NULL;
+
+  if (Private->Json != NULL) {
+    FreePool (Private->Json);
+    Private->Json = NULL;
+  }
+
+  return Status;
+}
+
+EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  mRedfishResourceConfig = {
+  RedfishResourceProvisioningResource,
+  RedfishResourceConsumeResource,
+  RedfishResourceUpdate,
+  RedfishResourceCheck,
+  RedfishResourceIdentify,
+  RedfishResourceGetInfo
+};
+
+/**
+  Initialize a Redfish configure handler.
+
+  This function will be called by the Redfish config driver to initialize each Redfish configure
+  handler.
+
+  @param[in]   This                     Pointer to EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL instance.
+  @param[in]   RedfishConfigServiceInfo Redfish service information.
+
+  @retval EFI_SUCCESS                  The handler has been initialized successfully.
+  @retval EFI_DEVICE_ERROR             Failed to create or configure the REST EX protocol instance.
+  @retval EFI_ALREADY_STARTED          This handler has already been initialized.
+  @retval Other                        Error happens during the initialization.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceInit (
+  IN  EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL  *This,
+  IN  REDFISH_CONFIG_SERVICE_INFORMATION     *RedfishConfigServiceInfo
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_CONFIG_PROTOCOL (This);
+
+  Private->RedfishService = RedfishCreateService (RedfishConfigServiceInfo);
+  if (Private->RedfishService == NULL) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Stop a Redfish configure handler.
+
+  @param[in]   This                Pointer to EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL instance.
+
+  @retval EFI_SUCCESS              This handler has been stoped successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceStop (
+  IN  EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL  *This
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_CONFIG_PROTOCOL (This);
+
+  if (Private->Event != NULL) {
+    gBS->CloseEvent (Private->Event);
+    Private->Event = NULL;
+  }
+
+  if (Private->RedfishService != NULL) {
+    RedfishCleanupService (Private->RedfishService);
+    Private->RedfishService = NULL;
+  }
+
+  return EFI_SUCCESS;
+}
+
+EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL  mRedfishConfigHandler = {
+  RedfishResourceInit,
+  RedfishResourceStop
+};
+
+/**
+  Callback function when gEfiRestJsonStructureProtocolGuid is installed.
+
+  @param[in] Event    Event whose notification function is being invoked.
+  @param[in] Context  Pointer to the notification function's context.
+**/
+VOID
+EFIAPI
+EfiRestJsonStructureProtocolIsReady (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mRedfishResourcePrivate == NULL) {
+    return;
+  }
+
+  if (mRedfishResourcePrivate->JsonStructProtocol != NULL) {
+    return;
+  }
+
+  Status = gBS->LocateProtocol (
+                  &gEfiRestJsonStructureProtocolGuid,
+                  NULL,
+                  (VOID **)&mRedfishResourcePrivate->JsonStructProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate gEfiRestJsonStructureProtocolGuid: %r\n", __func__, Status));
+  }
+
+  gBS->CloseEvent (Event);
+}
+
+/**
+  Unloads an image.
+
+  @param  ImageHandle           Handle that identifies the image to be unloaded.
+
+  @retval EFI_SUCCESS           The image has been unloaded.
+  @retval EFI_INVALID_PARAMETER ImageHandle is not a valid image handle.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceUnload (
+  IN EFI_HANDLE  ImageHandle
+  )
+{
+  EFI_STATUS                             Status;
+  EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL  *ConfigHandler;
+
+  if (mRedfishResourcePrivate == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ConfigHandler = NULL;
+
+  //
+  // Firstly, find ConfigHandler Protocol interface in this ImageHandle.
+  //
+  Status = gBS->OpenProtocol (
+                  ImageHandle,
+                  &gEdkIIRedfishConfigHandlerProtocolGuid,
+                  (VOID **)&ConfigHandler,
+                  NULL,
+                  NULL,
+                  EFI_OPEN_PROTOCOL_BY_HANDLE_PROTOCOL
+                  );
+  if (EFI_ERROR (Status) || (ConfigHandler == NULL)) {
+    return Status;
+  }
+
+  ConfigHandler->Stop (ConfigHandler);
+
+  //
+  // Last, uninstall ConfigHandler Protocol and resource protocol.
+  //
+  Status = gBS->UninstallMultipleProtocolInterfaces (
+                  ImageHandle,
+                  &gEdkIIRedfishConfigHandlerProtocolGuid,
+                  ConfigHandler,
+                  &gEdkIIRedfishResourceConfigProtocolGuid,
+                  &mRedfishResourcePrivate->RedfishResourceConfig,
+                  NULL
+                  );
+
+  FreePool (mRedfishResourcePrivate);
+  mRedfishResourcePrivate = NULL;
+
+  return Status;
+}
+
+/**
+  The callback function provided by Redfish Feature driver.
+
+  @param[in]     This                Pointer to EDKII_REDFISH_FEATURE_PROTOCOL instance.
+  @param[in]     FeatureAction       The action Redfish feature driver should take.
+  @param[in]     Uri                 The collection URI.
+  @param[in]     Context             The context of Redfish feature driver.
+  @param[in,out] InformationExchange The pointer to RESOURCE_INFORMATION_EXCHANGE
+
+  @retval EFI_SUCCESS              Redfish feature driver callback is executed successfully.
+  @retval Others                   Some errors happened.
+
+  @retval EFI_SUCCESS              Redfish feature driver callback is executed successfully.
+  @retval Others                   Some errors happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishExternalResourceResourceFeatureCallback (
+  IN     EDKII_REDFISH_FEATURE_PROTOCOL  *This,
+  IN     FEATURE_CALLBACK_ACTION         FeatureAction,
+  IN     VOID                            *Context,
+  IN OUT RESOURCE_INFORMATION_EXCHANGE   *InformationExchange
+  )
+{
+  EFI_STATUS                       Status;
+  REDFISH_SERVICE                  RedfishService;
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+  EFI_STRING                       ResourceUri;
+  EFI_STRING                       BiosUri;
+
+  if (FeatureAction != CallbackActionStartOperation) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Private = (REDFISH_RESOURCE_COMMON_PRIVATE *)Context;
+
+  RedfishService = Private->RedfishService;
+  if (RedfishService == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: no Redfish service configured\n", __func__));
+    return EFI_NOT_READY;
+  }
+
+  //
+  // Save in private structure.
+  //
+  Private->InformationExchange = InformationExchange;
+
+  //
+  // Find Redfish version on Redfish service.
+  //
+  Private->RedfishVersion = RedfishGetVersion (RedfishService);
+
+  //
+  // Create the full URI from Redfish service root.
+  //
+  ResourceUri = (EFI_STRING)AllocateZeroPool (MAX_URI_LENGTH * sizeof (CHAR16));
+  if (ResourceUri == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Fail to allocate memory for full URI.\n", __func__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  StrCatS (ResourceUri, MAX_URI_LENGTH, Private->RedfishVersion);
+  StrCatS (ResourceUri, MAX_URI_LENGTH, InformationExchange->SendInformation.FullUri);
+
+  //
+  // Initialize collection path
+  //
+  BiosUri = RedfishGetUri (ResourceUri);
+  if (BiosUri == NULL) {
+    ASSERT (FALSE);
+    FreePool (ResourceUri);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = HandleResource (Private, BiosUri);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, process external resource: %s failed: %r\n", __func__, BiosUri, Status));
+  }
+
+  FreePool (BiosUri);
+  FreePool (ResourceUri);
+  return Status;
+}
+
+/**
+  Callback function when gEdkIIRedfishFeatureProtocolGuid is installed.
+
+  @param[in] Event    Event whose notification function is being invoked.
+  @param[in] Context  Pointer to the notification function's context.
+**/
+VOID
+EFIAPI
+EdkIIRedfishFeatureProtocolIsReady (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EFI_STATUS                      Status;
+  EDKII_REDFISH_FEATURE_PROTOCOL  *FeatureProtocol;
+
+  if (mRedfishResourcePrivate == NULL) {
+    return;
+  }
+
+  if (mRedfishResourcePrivate->FeatureProtocol != NULL) {
+    return;
+  }
+
+  Status = gBS->LocateProtocol (
+                  &gEdkIIRedfishFeatureProtocolGuid,
+                  NULL,
+                  (VOID **)&FeatureProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate gEdkIIRedfishFeatureProtocolGuid: %r\n", __func__, Status));
+    gBS->CloseEvent (Event);
+    return;
+  }
+
+  Status = FeatureProtocol->Register (
+                              FeatureProtocol,
+                              REDFISH_MANAGED_URI,
+                              RedfishExternalResourceResourceFeatureCallback,
+                              (VOID *)mRedfishResourcePrivate
+                              );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to register %s: %r\n", __func__, REDFISH_MANAGED_URI, Status));
+  }
+
+  mRedfishResourcePrivate->FeatureProtocol = FeatureProtocol;
+
+  gBS->CloseEvent (Event);
+}
+
+/**
+  This is the declaration of an EFI image entry point. This entry point is
+  the same for UEFI Applications, UEFI OS Loaders, and UEFI Drivers including
+  both device drivers and bus drivers. It initialize the global variables and
+  publish the driver binding protocol.
+
+  @param[in]   ImageHandle      The firmware allocated handle for the UEFI image.
+  @param[in]   SystemTable      A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS           The operation completed successfully.
+  @retval EFI_ACCESS_DENIED     EFI_ISCSI_INITIATOR_NAME_PROTOCOL was installed unexpectedly.
+  @retval Others                Other errors as indicated.
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Registration;
+
+  if (mRedfishResourcePrivate != NULL) {
+    return EFI_ALREADY_STARTED;
+  }
+
+  mRedfishResourceConfigProtocolHandle = ImageHandle;
+
+  mRedfishResourcePrivate = AllocateZeroPool (sizeof (REDFISH_RESOURCE_COMMON_PRIVATE));
+  CopyMem (&mRedfishResourcePrivate->ConfigHandler, &mRedfishConfigHandler, sizeof (EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL));
+  CopyMem (&mRedfishResourcePrivate->RedfishResourceConfig, &mRedfishResourceConfig, sizeof (EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL));
+
+  //
+  // Publish config handler protocol and resource protocol.
+  //
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &ImageHandle,
+                  &gEdkIIRedfishConfigHandlerProtocolGuid,
+                  &mRedfishResourcePrivate->ConfigHandler,
+                  &gEdkIIRedfishResourceConfigProtocolGuid,
+                  &mRedfishResourcePrivate->RedfishResourceConfig,
+                  NULL
+                  );
+
+  EfiCreateProtocolNotifyEvent (
+    &gEfiRestJsonStructureProtocolGuid,
+    TPL_CALLBACK,
+    EfiRestJsonStructureProtocolIsReady,
+    NULL,
+    &Registration
+    );
+
+  EfiCreateProtocolNotifyEvent (
+    &gEdkIIRedfishFeatureProtocolGuid,
+    TPL_CALLBACK,
+    EdkIIRedfishFeatureProtocolIsReady,
+    (VOID *)mRedfishResourcePrivate,
+    &Registration
+    );
+
+  return Status;
+}

--- a/RedfishClientPkg/Features/Bios/v1_1_0/Dxe/BiosDxe.inf
+++ b/RedfishClientPkg/Features/Bios/v1_1_0/Dxe/BiosDxe.inf
@@ -1,0 +1,55 @@
+## @file
+#
+#  Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+  INF_VERSION               = 0x00010005
+  BASE_NAME                 = BiosDxe
+  FILE_GUID                 = A4CB3174-5D16-4CD8-9716-876AF2FB2D4B
+  MODULE_TYPE               = DXE_DRIVER
+  VERSION_STRING            = 1.0
+  ENTRY_POINT               = RedfishResourceEntryPoint
+  UNLOAD_IMAGE              = RedfishResourceUnload
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  RedfishPkg/RedfishPkg.dec
+  RedfishClientPkg/RedfishClientPkg.dec
+
+[Sources]
+  ../Common/BiosCommon.h
+  ../Common/BiosCommon.c
+  BiosDxe.c
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  EdkIIRedfishResourceConfigLib
+  RedfishHttpLib
+  RedfishFeatureUtilityLib
+  RedfishVersionLib
+  RedfishResourceIdentifyLib
+  UefiLib
+  UefiDriverEntryPoint
+  RedfishAddendumLib
+  PcdLib
+
+[Protocols]
+  gEdkIIRedfishConfigHandlerProtocolGuid          ## PRODUCED
+  gEfiRestJsonStructureProtocolGuid               ## CONSUMED
+  gEdkIIRedfishResourceConfigProtocolGuid         ## PRODUCED
+  gEdkIIRedfishFeatureProtocolGuid                ## CONSUMED
+
+[Pcd]
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport
+
+[Depex]
+  TRUE


### PR DESCRIPTION
# Description

Add Redfish Redfish driver for BIOS Schema 1.1.0.
We only handle BIOS Attributes in the feature driver.
- Use POST for the fresh Redfish BIOS resource.
- Use PUT for the Redfish BIOS resource update to overwrite the entire BIOS Redfish resource.

## How This Was Tested
With Redfish service BIOS schema 1.1.0 provided by BMC. Use this feature driver to provision, consume, and update the BIOS settings.
