### PR TITLE
RedfishClientPkg/ComputerSystem: Fix uninitialized variable usage

### DIFF
--- a/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Common/ComputerSystemCommon.c
+++ b/RedfishClientPkg/Features/ComputerSystem/v1_5_0/Common/ComputerSystemCommon.c
@@ -3,6 +3,7 @@
 
   (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2026 Qualcomm Technologies, Inc. All Rights Reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -797,6 +798,7 @@ ProvisioningComputerSystemProperties (
   ComputerSystem        = NULL;
   ComputerSystemCsEmpty = NULL;
   PatchedJson           = NULL;
+  ComputerSystemEmpty   = NULL;
 
   if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
     Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, InputJson, &PatchedJson);
@@ -817,13 +819,12 @@ ProvisioningComputerSystemProperties (
     goto ON_RELEASE;
   }
 
-  ComputerSystemEmpty = NULL;
-  Status              = JsonStructProtocol->ToStructure (
-                                              JsonStructProtocol,
-                                              NULL,
-                                              ComputerSystemEmptyJson,
-                                              (EFI_REST_JSON_STRUCTURE_HEADER **)&ComputerSystemEmpty
-                                              );
+  Status = JsonStructProtocol->ToStructure (
+                                 JsonStructProtocol,
+                                 NULL,
+                                 ComputerSystemEmptyJson,
+                                 (EFI_REST_JSON_STRUCTURE_HEADER **)&ComputerSystemEmpty
+                                 );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: ToStructure failure: %r\n", __func__, Status));
     goto ON_RELEASE;
@@ -1338,6 +1339,7 @@ ProvisioningComputerSystemResource (
     return EFI_INVALID_PARAMETER;
   }
 
+  NewResourceLocation = NULL;
   ZeroMem (&Response, sizeof (REDFISH_RESPONSE));
   AsciiSPrint (ResourceId, sizeof (ResourceId), "%d", Index);
 


### PR DESCRIPTION
- Initialize ComputerSystemEmpty before early goto exits to ensure cleanup paths do not operate on uninitialized data.
- Initialize NewResourceLocation to NULL at declaration to avoid use of uninitialized data.

# Description

Due to intermediate exits using goto for resource release in error handling scenarios, some variables were not initialized before being used during resource cleanup.
Fix the compilation error by initializing the NewResourceLocation variable correctly.

## How This Was Tested

Tested on Qualcomm Platform
