### PR TITLE
Implement PCIe device inventory information

### DIFF
--- a/RedfishClientPkg/Features/PcieDevice/v1_9_0/Common/PcieDeviceCommon.c
+++ b/RedfishClientPkg/Features/PcieDevice/v1_9_0/Common/PcieDeviceCommon.c
@@ -1,0 +1,582 @@
+/** @file
+  Redfish feature driver implementation - common functions
+
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "PcieDeviceCommon.h"
+#include <Library/PrintLib.h>
+
+CHAR8  PcieDeviceEmptyJson[] = "{\"@odata.id\": \"\", \"@odata.type\": \"#PCIeDevice.v1_9_0.PCIeDevice\", \"Id\": \"\", \"Name\": \"\"}";
+
+REDFISH_RESOURCE_COMMON_PRIVATE  *mRedfishResourcePrivate             = NULL;
+EFI_HANDLE                       mRedfishResourceConfigProtocolHandle = NULL;
+REDFISH_SCHEMA_INFO              mSchemaInfo                          = {
+  { RESOURCE_SCHEMA        },
+  { RESOURCE_SCHEMA_MAJOR  },
+  { RESOURCE_SCHEMA_MINOR  },
+  { RESOURCE_SCHEMA_ERRATA }
+};
+
+/**
+  Consume resource from given URI.
+
+  @param[in]   This                Pointer to REDFISH_RESOURCE_COMMON_PRIVATE instance.
+  @param[in]   Json                The JSON to consume.
+  @param[in]   HeaderEtag          The Etag string returned in HTTP header.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishConsumeResourceCommon (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN  CHAR8                            *Json,
+  IN  CHAR8                            *HeaderEtag OPTIONAL
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Find the content after the opening brace of a JSON object.
+
+  @param[in]   JsonString  The JSON string to parse.
+
+  @return  Pointer to the content after the opening '{', or
+           pointer to the end of string if '{' is not found.
+
+**/
+CHAR8 *
+GetJsonObjectContent (
+  IN  CHAR8  *JsonString
+  )
+{
+  CHAR8  *Cursor;
+
+  Cursor = JsonString;
+  while ((*Cursor != '\0') && (*Cursor != '{')) {
+    Cursor++;
+  }
+
+  if (*Cursor == '{') {
+    Cursor++;
+  }
+
+  return Cursor;
+}
+
+/**
+  Patch PCIe interface properties into JSON output.
+
+  @param[in]      ThisPcieTopology  Pointer to REDFISH_SYSTEM_TOPOLOGY_PCIE.
+  @param[in,out]  Json              On input, the original JSON.
+                                    On output, the patched JSON.
+
+  @retval EFI_SUCCESS               JSON was patched successfully.
+  @retval EFI_INVALID_PARAMETER     Input parameter is NULL.
+  @retval EFI_OUT_OF_RESOURCES      Failed to allocate memory.
+
+**/
+EFI_STATUS
+PatchPCIeInterface (
+  IN      REDFISH_SYSTEM_TOPOLOGY_PCIE  *ThisPcieTopology,
+  IN OUT  CHAR8                         **Json
+  )
+{
+  CHAR8  *PatchedJson;
+  CHAR8  *OriginalJson;
+  CHAR8  *JsonContent;
+  UINTN  PatchedJsonLen;
+
+  if ((ThisPcieTopology == NULL) || (Json == NULL) || (*Json == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  PatchedJson  = NULL;
+  OriginalJson = *Json;
+  JsonContent  = GetJsonObjectContent (OriginalJson);
+
+  PatchedJsonLen = AsciiStrLen (OriginalJson) * 2;
+
+  PatchedJson = AllocateZeroPool (PatchedJsonLen);
+  if (PatchedJson == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  AsciiSPrint (
+    PatchedJson,
+    PatchedJsonLen,
+    "{\n\"MaxLanes\": %d,\n\"LanesInUse\": %d,\n\"MaxPCIeType\": \"%d\",\n\"PCIeType\": \"%d\",\n%a",
+    ThisPcieTopology->MaxLanes,
+    ThisPcieTopology->LanesInUse,
+    ThisPcieTopology->MaxPCIeType,
+    ThisPcieTopology->PCIeType,
+    JsonContent
+    );
+
+  FreePool (*Json);
+  *Json = PatchedJson;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Provisioning one redfish PCIeDevice resource.
+
+  @param[in]    JsonStructProtocol  Pointer to EFI_REST_JSON_STRUCTURE_PROTOCOL.
+  @param[in]    InputJson           Input PCIeDevice JSON template.
+  @param[in]    ThisPcieTopology    Pointer to this REDFISH_SYSTEM_TOPOLOGY_PCIE.
+  @param[in]    IsCreateOrUpdate    Is to create the new resource of PCIeDevice.
+  @param[out]   ResultJson          The result JSON of new PCIeDevice resource.
+
+  @retval EFI_SUCCESS               PCIeDevice resource is provisioned successfully.
+  @retval Others                    Some error happened.
+
+**/
+EFI_STATUS
+ProvisioningPcieProperties (
+  IN  EFI_REST_JSON_STRUCTURE_PROTOCOL  *JsonStructProtocol,
+  IN  CHAR8                             *InputJson,
+  IN  REDFISH_SYSTEM_TOPOLOGY_PCIE      *ThisPcieTopology,
+  IN  BOOLEAN                           IsCreateOrUpdate,
+  OUT CHAR8                             **ResultJson
+  )
+{
+  EFI_REDFISH_PCIEDEVICE_V1_9_0     *PcieDevice;
+  EFI_REDFISH_PCIEDEVICE_V1_9_0_CS  *PcieDeviceCs;
+  EFI_STATUS                        Status;
+  CHAR8                             *PatchedJson;
+  UINTN                             StringLength;
+
+  if ((JsonStructProtocol == NULL) || (ResultJson == NULL) || IS_EMPTY_STRING (InputJson)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // 17 bytes covers "%08x%08x" (16 hex + null) for SerialNumber,
+  // "Single Function" (15 + null) for DeviceType, and "%04x" for
+  // Manufacturer/Model. Use 32 for safety margin.
+  //
+  StringLength = 32;
+
+  DEBUG ((
+    REDFISH_DEBUG_TRACE,
+    "%a provision PCIeDevice with: %s\n",
+    __func__,
+    (IsCreateOrUpdate ? L"Provision resource" : L"Update resource")
+    ));
+
+  *ResultJson = NULL;
+  PcieDevice  = NULL;
+  PatchedJson = NULL;
+
+  if (PcdGetBool (PcdRedfishCompatibleSchemaSupport)) {
+    Status = RedfishSetCompatibleSchemaVersion (&mSchemaInfo, InputJson, &PatchedJson);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a, cannot set compatible schema version: %r\n", __func__, Status));
+      return Status;
+    }
+  }
+
+  Status = JsonStructProtocol->ToStructure (
+                                 JsonStructProtocol,
+                                 NULL,
+                                 (PatchedJson == NULL ? InputJson : PatchedJson),
+                                 (EFI_REST_JSON_STRUCTURE_HEADER **)&PcieDevice
+                                 );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, ToStructure failure: %r\n", __func__, Status));
+    goto ON_RELEASE;
+  }
+
+  PcieDeviceCs = PcieDevice->PCIeDevice;
+
+  //
+  // Handle SerialNumber
+  //
+  PcieDeviceCs->SerialNumber = AllocateZeroPool (StringLength);
+  if (PcieDeviceCs->SerialNumber != NULL) {
+    AsciiSPrint (
+      PcieDeviceCs->SerialNumber,
+      StringLength,
+      "%08x%08x",
+      ThisPcieTopology->SerialNumber.Upper,
+      ThisPcieTopology->SerialNumber.Lower
+      );
+    DEBUG ((DEBUG_INFO, "Serial Number = %a\n", PcieDeviceCs->SerialNumber));
+  }
+
+  PcieDeviceCs->DeviceType = AllocateZeroPool (StringLength);
+  if (PcieDeviceCs->DeviceType != NULL) {
+    AsciiSPrint (
+      PcieDeviceCs->DeviceType,
+      StringLength,
+      "%a",
+      ThisPcieTopology->DeviceType ? "Multi Function" : "Single Function"
+      );
+    DEBUG ((DEBUG_INFO, "Device Type = %a\n", PcieDeviceCs->DeviceType));
+  }
+
+  PcieDeviceCs->Manufacturer = AllocateZeroPool (StringLength);
+  if (PcieDeviceCs->Manufacturer != NULL) {
+    AsciiSPrint (
+      PcieDeviceCs->Manufacturer,
+      StringLength,
+      "%04x",
+      ThisPcieTopology->Manufacturer
+      );
+    DEBUG ((DEBUG_INFO, "Manufacturer = %a\n", PcieDeviceCs->Manufacturer));
+  }
+
+  PcieDeviceCs->Model = AllocateZeroPool (StringLength);
+  if (PcieDeviceCs->Model != NULL) {
+    AsciiSPrint (
+      PcieDeviceCs->Model,
+      StringLength,
+      "%04x",
+      ThisPcieTopology->Model
+      );
+    DEBUG ((DEBUG_INFO, "Model = %a\n", PcieDeviceCs->Model));
+  }
+
+  //
+  // Convert C structure back to JSON text.
+  //
+  Status = JsonStructProtocol->ToJson (
+                                 JsonStructProtocol,
+                                 (EFI_REST_JSON_STRUCTURE_HEADER *)PcieDevice,
+                                 ResultJson
+                                 );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, ToJson() failed: %r\n", __func__, Status));
+    goto ON_RELEASE;
+  }
+
+  Status = PatchPCIeInterface (ThisPcieTopology, ResultJson);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, PatchPCIeInterface() failed: %r\n", __func__, Status));
+  }
+
+ON_RELEASE:
+  //
+  // Release resource.
+  //
+  if (PcieDevice != NULL) {
+    JsonStructProtocol->DestoryStructure (
+                          JsonStructProtocol,
+                          (EFI_REST_JSON_STRUCTURE_HEADER *)PcieDevice
+                          );
+  }
+
+  if (PatchedJson != NULL) {
+    FreePool (PatchedJson);
+  }
+
+  return Status;
+}
+
+/**
+  Provisioning one redfish PCIeDevice resource.
+
+  @param[in]    Private           Pointer to REDFISH_RESOURCE_COMMON_PRIVATE.
+  @param[in]    ThisPcieTopology  Pointer to this REDFISH_SYSTEM_TOPOLOGY_PCIE.
+  @param[in]    PciIndexId        Zero-based index of PCIe device.
+  @param[out]   UriReturned       The URI returned that contains newly created resource.
+
+  @retval EFI_SUCCESS             PCIeDevice resource is provisioned successfully.
+  @retval Others                  Some error happened.
+
+**/
+EFI_STATUS
+ProvisioningPcieDeviceResource (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN  REDFISH_SYSTEM_TOPOLOGY_PCIE     *ThisPcieTopology,
+  IN  UINTN                            PciIndexId,
+  OUT CHAR8                            **UriReturned
+  )
+{
+  CHAR8             *Json;
+  EFI_STATUS        Status;
+  EFI_STRING        NewResourceLocation;
+  CHAR16            ResourceId[16];
+  CHAR16            *UriInstance;
+  UINTN             SizeString;
+  UINTN             UriLen;
+  REDFISH_RESPONSE  Response;
+
+  if ((Private == NULL) || (ThisPcieTopology == NULL) || (UriReturned == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *UriReturned        = NULL;
+  Json                = NULL;
+  UriInstance         = NULL;
+  NewResourceLocation = NULL;
+
+  ZeroMem (&Response, sizeof (REDFISH_RESPONSE));
+  UnicodeSPrint (ResourceId, sizeof (ResourceId), L"%d", PciIndexId);
+
+  Status = ProvisioningPcieProperties (
+             Private->JsonStructProtocol,
+             PcieDeviceEmptyJson,
+             ThisPcieTopology,
+             TRUE,
+             &Json
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a, provisioning resource for #%d PCIe device failed: %r\n",
+      __func__,
+      PciIndexId,
+      Status
+      ));
+    return Status;
+  }
+
+  //
+  // Generate the URI for the new resource
+  //
+  SizeString  = (StrLen (Private->Uri) + StrLen (L"/") + StrLen (ResourceId) + 1) * sizeof (CHAR16);
+  UriInstance = AllocateZeroPool (SizeString);
+  if (UriInstance == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a, failed to allocate memory for URI\n", __func__));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto RELEASE_RESOURCE;
+  }
+
+  UnicodeSPrint (UriInstance, SizeString, L"%s%s%s", Private->Uri, L"/", ResourceId);
+  Status = RedfishHttpPostResource (Private->RedfishService, UriInstance, Json, &Response);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, post PCIe resource failed: %r\n", __func__, Status));
+    goto RELEASE_RESOURCE;
+  }
+
+  //
+  // Per Redfish spec. the URL of new resource will be returned in "Location" header.
+  //
+  Status = GetHttpResponseLocation (&Response, &NewResourceLocation);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: cannot find new location: %r\n", __func__, Status));
+    goto RELEASE_RESOURCE;
+  }
+
+  //
+  // Keep location of new resource.
+  //
+  if (NewResourceLocation != NULL) {
+    DEBUG ((DEBUG_MANAGEABILITY, "%a: Location: %s\n", __func__, NewResourceLocation));
+
+    UriLen       = StrLen (NewResourceLocation) + 1;
+    *UriReturned = AllocateZeroPool (UriLen);
+    if (*UriReturned != NULL) {
+      UnicodeStrToAsciiStrS (NewResourceLocation, *UriReturned, UriLen);
+    }
+  }
+
+RELEASE_RESOURCE:
+  RedfishHttpFreeResponse (&Response);
+
+  if (NewResourceLocation != NULL) {
+    FreePool (NewResourceLocation);
+  }
+
+  if (Json != NULL) {
+    FreePool (Json);
+  }
+
+  if (UriInstance != NULL) {
+    FreePool (UriInstance);
+  }
+
+  return Status;
+}
+
+/**
+  Provisioning redfish PCIeDevice resources.
+
+  @param[in]   Private             Pointer to REDFISH_RESOURCE_COMMON_PRIVATE.
+
+  @retval EFI_SUCCESS              PCIeDevice resources are provisioned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+ProvisioningPcieDeviceResources (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private
+  )
+{
+  UINTN                                 NumberOfPcie;
+  UINTN                                 Index;
+  EFI_STATUS                            Status;
+  EDKII_REDFISH_SYSTEM_TOPOLOGY_DEVICE  *PciTopology;
+  CHAR8                                 **PcieResourceUri;
+  CHAR8                                 **UriReturned;
+  REDFISH_FEATURE_ARRAY_TYPE_URI        *ReturnUris;
+
+  if (Private == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NumberOfPcie = 0;
+  Status       = RedfishSystemTopologyGetCount (REDFISH_SYSTEM_TOPOLOGY_TYPE_PCIE, &NumberOfPcie);
+  DEBUG ((DEBUG_INFO, "NumberOfPcie = %d\n", NumberOfPcie));
+  if (EFI_ERROR (Status)) {
+    if ((Status == EFI_NOT_FOUND) || (NumberOfPcie == 0)) {
+      DEBUG ((REDFISH_DEBUG_TRACE, "%a, No PCIe device to provision.\n", __func__));
+      return EFI_SUCCESS;
+    } else {
+      DEBUG ((DEBUG_ERROR, "%a, Failed to get Pcie device count.\n", __func__));
+      return Status;
+    }
+  }
+
+  PcieResourceUri = AllocateZeroPool (sizeof (CHAR8 *) * NumberOfPcie);
+  if (PcieResourceUri == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Not enough memory for PCIeResourceUri\n", __func__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  PciTopology = NULL;
+  UriReturned = PcieResourceUri;
+
+  for (Index = 0; Index < NumberOfPcie; Index++) {
+    Status = RedfishGetSystemTopologyGetEntry (REDFISH_SYSTEM_TOPOLOGY_TYPE_PCIE, &PciTopology);
+    if (EFI_ERROR (Status) || (PciTopology == NULL)) {
+      DEBUG ((DEBUG_INFO, "%a: topology iterator exhausted at index %d\n", __func__, Index));
+      break;
+    }
+
+    Status = ProvisioningPcieDeviceResource (
+               Private,
+               &PciTopology->DeviceType.PcieDevice,
+               Index,
+               UriReturned
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to provision PCIe device #%d\n", __func__, Index));
+    } else {
+      UriReturned++;
+    }
+  }
+
+  //
+  // Set up the return exchange information.
+  //
+  ReturnUris = AllocateZeroPool (sizeof (REDFISH_FEATURE_ARRAY_TYPE_URI));
+  if (ReturnUris == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a, Not enough memory for REDFISH_FEATURE_ARRAY_TYPE_URI\n", __func__));
+    FreePool (PcieResourceUri);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ReturnUris->Count = (UINTN)(UriReturned - PcieResourceUri);
+  ReturnUris->List  = PcieResourceUri;
+
+  Private->InformationExchange->ReturnedInformation.Type                            = InformationTypeArrayMemberUri;
+  Private->InformationExchange->ReturnedInformation.ResourceTypeReturnedInformation = ReturnUris;
+  return EFI_SUCCESS;
+}
+
+/**
+  Provisioning existing redfish PCIeDevice resource.
+
+  @param[in]   Private             Pointer to REDFISH_RESOURCE_COMMON_PRIVATE.
+
+  @retval EFI_UNSUPPORTED          This function is not supported.
+
+**/
+EFI_STATUS
+ProvisioningPcieDeviceExistResource (
+  IN  REDFISH_RESOURCE_COMMON_PRIVATE  *Private
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Provisioning redfish resource by given URI.
+
+  @param[in]   This                Pointer to REDFISH_RESOURCE_COMMON_PRIVATE instance.
+  @param[in]   ResourceExist       TRUE if resource exists, PUT method will be used.
+                                   FALSE if resource does not exist POST method is used.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishProvisioningResourceCommon (
+  IN     REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN     BOOLEAN                          ResourceExist
+  )
+{
+  if (Private == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return (ResourceExist ? ProvisioningPcieDeviceExistResource (Private) : ProvisioningPcieDeviceResources (Private));
+}
+
+/**
+  Check resource from given URI.
+
+  @param[in]   This                Pointer to REDFISH_RESOURCE_COMMON_PRIVATE instance.
+  @param[in]   Json                The JSON to consume.
+  @param[in]   HeaderEtag          The Etag string returned in HTTP header.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishCheckResourceCommon (
+  IN     REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN     CHAR8                            *Json,
+  IN     CHAR8                            *HeaderEtag OPTIONAL
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  Update resource to given URI.
+
+  @param[in]   This                Pointer to REDFISH_RESOURCE_COMMON_PRIVATE instance.
+  @param[in]   Json                The JSON to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishUpdateResourceCommon (
+  IN     REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN     CHAR8                            *InputJson
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  Identify resource from given URI.
+
+  @param[in]   This                Pointer to REDFISH_RESOURCE_COMMON_PRIVATE instance.
+  @param[in]   Json                The JSON to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishIdentifyResourceCommon (
+  IN     REDFISH_RESOURCE_COMMON_PRIVATE  *Private,
+  IN     CHAR8                            *Json
+  )
+{
+  return EFI_SUCCESS;
+}

--- a/RedfishClientPkg/Features/PcieDevice/v1_9_0/Common/PcieDeviceCommon.h
+++ b/RedfishClientPkg/Features/PcieDevice/v1_9_0/Common/PcieDeviceCommon.h
@@ -1,0 +1,26 @@
+/** @file
+  Redfish feature driver implementation - internal header file
+
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef EFI_REDFISH_PCIEDEVICE_COMMON_H_
+#define EFI_REDFISH_PCIEDEVICE_COMMON_H_
+
+#include <RedfishJsonStructure/PCIeDevice/v1_9_0/EfiPCIeDeviceV1_9_0.h>
+#include <Library/RedfishSystemTopologyLib.h>
+#include <RedfishResourceCommon.h>
+
+//
+// Schema information.
+//
+#define RESOURCE_SCHEMA          "PCIeDevice"
+#define RESOURCE_SCHEMA_MAJOR    "1"
+#define RESOURCE_SCHEMA_MINOR    "9"
+#define RESOURCE_SCHEMA_ERRATA   "0"
+#define RESOURCE_SCHEMA_VERSION  "v1_9_0"
+#define RESOURCE_SCHEMA_FULL     "x-UEFI-redfish-PCIeDevice.v1_9_0"
+
+#endif

--- a/RedfishClientPkg/Features/PcieDevice/v1_9_0/Dxe/PcieDeviceDxe.c
+++ b/RedfishClientPkg/Features/PcieDevice/v1_9_0/Dxe/PcieDeviceDxe.c
@@ -1,0 +1,565 @@
+/** @file
+  Redfish feature driver implementation - PCIeDevice
+
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "../Common/PcieDeviceCommon.h"
+
+extern REDFISH_RESOURCE_COMMON_PRIVATE  *mRedfishResourcePrivate;
+extern EFI_HANDLE                       mRedfishResourceConfigProtocolHandle;
+
+/**
+  Locate interchange data protocol.
+
+  @param[in]   Handle           The ConfigHandle protocol.
+  @param[out]  InterchangeData  The pointer to receive
+                                EDKII_REDFISH_FEATURE_INTERCHANGE_DATA_PROTOCOL.
+
+  @retval EFI_SUCCESS              EDKII_REDFISH_FEATURE_INTERCHANGE_DATA_PROTOCOL
+                                   is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+RedfishLocateInterchangeData (
+  IN   EFI_HANDLE                                       Handle,
+  OUT  EDKII_REDFISH_FEATURE_INTERCHANGE_DATA_PROTOCOL  **InterchangeData
+  )
+{
+  EFI_STATUS                                       Status;
+  EDKII_REDFISH_FEATURE_INTERCHANGE_DATA_PROTOCOL  *Interface;
+
+  if ((Handle == NULL) || (InterchangeData == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = gBS->HandleProtocol (
+                  Handle,
+                  &gEdkIIRedfishFeatureInterchangeDataProtocolGuid,
+                  (VOID **)&Interface
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: EDKII_REDFISH_FEATURE_INTERCHANGE_DATA_PROTOCOL is not installed on %p: %r\n",
+      __func__,
+      Handle,
+      Status
+      ));
+    return Status;
+  }
+
+  *InterchangeData = Interface;
+  return EFI_SUCCESS;
+}
+
+/**
+  Provisioning redfish resource by given URI.
+
+  @param[in]   This                Pointer to EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL instance.
+  @param[in]   Uri                 Target URI to create resource.
+  @param[in]   CreateResource      TRUE if the resource does not exist, we have to create the new
+                                        resource.
+                                   FALSE if the resource exist but property is missing, we have to
+                                         update the resource.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceProvisioningResource (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri,
+  IN     BOOLEAN                                 CreateResource
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE                  *Private;
+  EFI_STATUS                                       Status;
+  EDKII_REDFISH_FEATURE_INTERCHANGE_DATA_PROTOCOL  *InterchangeData;
+
+  if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((DEBUG_MANAGEABILITY, "%a, provisioning in %s mode\n", __func__, (CreateResource ? L"POST" : L"PATCH")));
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
+
+  if (Private->RedfishService == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  Status = RedfishLocateInterchangeData (mRedfishResourceConfigProtocolHandle, &InterchangeData);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Private->InformationExchange = InterchangeData->ResourceInformationExchage;
+  Private->Uri                 = Uri;
+
+  Status = RedfishProvisioningResourceCommon (Private, !CreateResource);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to provision resource to: %s: %r\n", __func__, Uri, Status));
+  }
+
+  return Status;
+}
+
+/**
+  Consume resource from given URI.
+
+  @param[in]   This                Pointer to EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL instance.
+  @param[in]   Uri                 The target URI to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceConsumeResource (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Get information about this protocol.
+
+  @param[in]   This                Pointer to EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL instance.
+  @param[out]  Info                Supported schema information.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceGetInfo (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  OUT    REDFISH_SCHEMA_INFO                     *Info
+  )
+{
+  if ((This == NULL) || (Info == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  AsciiStrCpyS (Info->Schema, REDFISH_SCHEMA_STRING_SIZE, RESOURCE_SCHEMA);
+  AsciiStrCpyS (Info->Major, REDFISH_SCHEMA_VERSION_SIZE, RESOURCE_SCHEMA_MAJOR);
+  AsciiStrCpyS (Info->Minor, REDFISH_SCHEMA_VERSION_SIZE, RESOURCE_SCHEMA_MINOR);
+  AsciiStrCpyS (Info->Errata, REDFISH_SCHEMA_VERSION_SIZE, RESOURCE_SCHEMA_ERRATA);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Update resource to given URI.
+
+  @param[in]   This                Pointer to EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL instance.
+  @param[in]   Uri                 The target URI to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceUpdate (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Check resource on given URI.
+
+  @param[in]   This                Pointer to EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL instance.
+  @param[in]   Uri                 The target URI to consume.
+
+  @retval EFI_SUCCESS              Value is returned successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceCheck (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+  EFI_STATUS                       Status;
+  REDFISH_RESPONSE                 Response;
+  CHAR8                            *Etag;
+
+  if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
+
+  if (Private->RedfishService == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, NULL, &Response, TRUE);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
+    return Status;
+  }
+
+  Private->Uri     = Uri;
+  Private->Payload = Response.Payload;
+  ASSERT (Private->Payload != NULL);
+
+  Private->Json = JsonDumpString (RedfishJsonInPayload (Private->Payload), EDKII_JSON_COMPACT);
+  ASSERT (Private->Json != NULL);
+
+  //
+  // Find etag in HTTP response header
+  //
+  Etag   = NULL;
+  Status = GetHttpResponseEtag (&Response, &Etag);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to get ETag from HTTP header\n", __func__));
+  }
+
+  Status = RedfishCheckResourceCommon (Private, Private->Json, Etag);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, failed to check resource from: %s: %r\n", __func__, Uri, Status));
+  }
+
+  //
+  // Release resource
+  //
+  if (Etag != NULL) {
+    FreePool (Etag);
+  }
+
+  RedfishHttpFreeResponse (&Response);
+  Private->Payload = NULL;
+
+  if (Private->Json != NULL) {
+    FreePool (Private->Json);
+    Private->Json = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Identify resource on given URI.
+
+  @param[in]   This                Pointer to EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL instance.
+  @param[in]   Uri                 The target URI to consume.
+
+  @retval EFI_SUCCESS              This is target resource which we want to handle.
+  @retval EFI_UNSUPPORTED          This is not the target resource.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceIdentify (
+  IN     EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  *This,
+  IN     EFI_STRING                              Uri
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+  EFI_STATUS                       Status;
+  REDFISH_RESPONSE                 Response;
+
+  if ((This == NULL) || IS_EMPTY_STRING (Uri)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_RESOURCE_PROTOCOL (This);
+
+  if (Private->RedfishService == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ZeroMem (&Response, sizeof (Response));
+  Status = RedfishHttpGetResource (Private->RedfishService, Uri, NULL, &Response, TRUE);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, get resource from: %s failed\n", __func__, Uri));
+    return Status;
+  }
+
+  Private->Uri     = Uri;
+  Private->Payload = Response.Payload;
+  ASSERT (Private->Payload != NULL);
+
+  Private->Json = JsonDumpString (RedfishJsonInPayload (Private->Payload), EDKII_JSON_COMPACT);
+  ASSERT (Private->Json != NULL);
+
+  Status = RedfishIdentifyResourceCommon (Private, Private->Json);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, identify %s failed: %r\n", __func__, Uri, Status));
+  }
+
+  //
+  // Release resource
+  //
+  RedfishHttpFreeResponse (&Response);
+  Private->Payload = NULL;
+
+  if (Private->Json != NULL) {
+    FreePool (Private->Json);
+    Private->Json = NULL;
+  }
+
+  return Status;
+}
+
+EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL  mRedfishResourceConfig = {
+  RedfishResourceProvisioningResource,
+  RedfishResourceConsumeResource,
+  RedfishResourceUpdate,
+  RedfishResourceCheck,
+  RedfishResourceIdentify,
+  RedfishResourceGetInfo
+};
+
+/**
+  Initialize a Redfish configure handler.
+
+  This function will be called by the Redfish config driver to initialize each Redfish configure
+  handler.
+
+  @param[in]   This                     Pointer to EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL instance.
+  @param[in]   RedfishConfigServiceInfo Redfish service information.
+
+  @retval EFI_SUCCESS                  The handler has been initialized successfully.
+  @retval EFI_DEVICE_ERROR             Failed to create or configure the REST EX protocol instance.
+  @retval EFI_ALREADY_STARTED          This handler has already been initialized.
+  @retval Other                        Error happens during the initialization.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceInit (
+  IN  EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL  *This,
+  IN  REDFISH_CONFIG_SERVICE_INFORMATION     *RedfishConfigServiceInfo
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_CONFIG_PROTOCOL (This);
+
+  Private->RedfishService = RedfishCreateService (RedfishConfigServiceInfo);
+  if (Private->RedfishService == NULL) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Stop a Redfish configure handler.
+
+  @param[in]   This                Pointer to EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL instance.
+
+  @retval EFI_SUCCESS              This handler has been stoped successfully.
+  @retval Others                   Some error happened.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceStop (
+  IN  EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL  *This
+  )
+{
+  REDFISH_RESOURCE_COMMON_PRIVATE  *Private;
+
+  Private = REDFISH_RESOURCE_COMMON_PRIVATE_DATA_FROM_CONFIG_PROTOCOL (This);
+
+  if (Private->Event != NULL) {
+    gBS->CloseEvent (Private->Event);
+    Private->Event = NULL;
+  }
+
+  if (Private->RedfishService != NULL) {
+    RedfishCleanupService (Private->RedfishService);
+    Private->RedfishService = NULL;
+  }
+
+  return EFI_SUCCESS;
+}
+
+EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL  mRedfishConfigHandler = {
+  RedfishResourceInit,
+  RedfishResourceStop
+};
+
+/**
+  Callback function when gEfiRestJsonStructureProtocolGuid is installed.
+
+  @param[in] Event    Event whose notification function is being invoked.
+  @param[in] Context  Pointer to the notification function's context.
+**/
+VOID
+EFIAPI
+EfiRestJsonStructureProtocolIsReady (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mRedfishResourcePrivate == NULL) {
+    return;
+  }
+
+  if (mRedfishResourcePrivate->JsonStructProtocol != NULL) {
+    return;
+  }
+
+  Status = gBS->LocateProtocol (
+                  &gEfiRestJsonStructureProtocolGuid,
+                  NULL,
+                  (VOID **)&mRedfishResourcePrivate->JsonStructProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, failed to locate gEfiRestJsonStructureProtocolGuid: %r\n", __func__, Status));
+  }
+
+  gBS->CloseEvent (Event);
+}
+
+/**
+  Unloads an image.
+
+  @param[in]  ImageHandle        Handle that identifies the image to be unloaded.
+
+  @retval EFI_SUCCESS           The image has been unloaded.
+  @retval EFI_INVALID_PARAMETER ImageHandle is not a valid image handle.
+
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceUnload (
+  IN EFI_HANDLE  ImageHandle
+  )
+{
+  EFI_STATUS                             Status;
+  EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL  *ConfigHandler;
+
+  if (mRedfishResourcePrivate == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  ConfigHandler = NULL;
+
+  //
+  // Firstly, find ConfigHandler Protocol interface in this ImageHandle.
+  //
+  Status = gBS->OpenProtocol (
+                  ImageHandle,
+                  &gEdkIIRedfishConfigHandlerProtocolGuid,
+                  (VOID **)&ConfigHandler,
+                  NULL,
+                  NULL,
+                  EFI_OPEN_PROTOCOL_BY_HANDLE_PROTOCOL
+                  );
+  if (EFI_ERROR (Status) || (ConfigHandler == NULL)) {
+    return Status;
+  }
+
+  ConfigHandler->Stop (ConfigHandler);
+
+  //
+  // Last, uninstall ConfigHandler Protocol and resource protocol.
+  //
+  Status = gBS->UninstallMultipleProtocolInterfaces (
+                  ImageHandle,
+                  &gEdkIIRedfishConfigHandlerProtocolGuid,
+                  ConfigHandler,
+                  &gEdkIIRedfishResourceConfigProtocolGuid,
+                  &mRedfishResourcePrivate->RedfishResourceConfig,
+                  NULL
+                  );
+
+  FreePool (mRedfishResourcePrivate);
+  mRedfishResourcePrivate = NULL;
+
+  return Status;
+}
+
+/**
+  This is the declaration of an EFI image entry point. This entry point is
+  the same for UEFI Applications, UEFI OS Loaders, and UEFI Drivers including
+  both device drivers and bus drivers. It initialize the global variables and
+  publish the driver binding protocol.
+
+  @param[in]   ImageHandle      The firmware allocated handle for the UEFI image.
+  @param[in]   SystemTable      A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS           The operation completed successfully.
+  @retval EFI_ACCESS_DENIED     EFI_ISCSI_INITIATOR_NAME_PROTOCOL was installed unexpectedly.
+  @retval Others                Other errors as indicated.
+**/
+EFI_STATUS
+EFIAPI
+RedfishResourceEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Registration;
+
+  if (mRedfishResourcePrivate != NULL) {
+    return EFI_ALREADY_STARTED;
+  }
+
+  mRedfishResourceConfigProtocolHandle = ImageHandle;
+
+  mRedfishResourcePrivate = AllocateZeroPool (sizeof (REDFISH_RESOURCE_COMMON_PRIVATE));
+  if (mRedfishResourcePrivate == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (
+    &mRedfishResourcePrivate->ConfigHandler,
+    &mRedfishConfigHandler,
+    sizeof (EDKII_REDFISH_CONFIG_HANDLER_PROTOCOL)
+    );
+  CopyMem (
+    &mRedfishResourcePrivate->RedfishResourceConfig,
+    &mRedfishResourceConfig,
+    sizeof (EDKII_REDFISH_RESOURCE_CONFIG_PROTOCOL)
+    );
+
+  //
+  // Publish config handler protocol and resource protocol.
+  //
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &ImageHandle,
+                  &gEdkIIRedfishConfigHandlerProtocolGuid,
+                  &mRedfishResourcePrivate->ConfigHandler,
+                  &gEdkIIRedfishResourceConfigProtocolGuid,
+                  &mRedfishResourcePrivate->RedfishResourceConfig,
+                  NULL
+                  );
+
+  EfiCreateProtocolNotifyEvent (
+    &gEfiRestJsonStructureProtocolGuid,
+    TPL_CALLBACK,
+    EfiRestJsonStructureProtocolIsReady,
+    NULL,
+    &Registration
+    );
+
+  return Status;
+}

--- a/RedfishClientPkg/Features/PcieDevice/v1_9_0/Dxe/PcieDeviceDxe.inf
+++ b/RedfishClientPkg/Features/PcieDevice/v1_9_0/Dxe/PcieDeviceDxe.inf
@@ -1,0 +1,55 @@
+## @file
+#
+#  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION               = 0x00010005
+  BASE_NAME                 = PcieDeviceDxe
+  FILE_GUID                 = 1bd84df4-697c-4984-9232-1d03e109b079
+  MODULE_TYPE               = DXE_DRIVER
+  VERSION_STRING            = 1.0
+  ENTRY_POINT               = RedfishResourceEntryPoint
+  UNLOAD_IMAGE              = RedfishResourceUnload
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  RedfishPkg/RedfishPkg.dec
+  RedfishClientPkg/RedfishClientPkg.dec
+
+[Sources]
+  ../Common/PcieDeviceCommon.h
+  ../Common/PcieDeviceCommon.c
+  PcieDeviceDxe.c
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  EdkIIRedfishResourceConfigLib
+  MemoryAllocationLib
+  PcdLib
+  PrintLib
+  RedfishHttpLib
+  RedfishFeatureUtilityLib
+  RedfishResourceIdentifyLib
+  RedfishSystemTopologyLib
+  UefiLib
+  UefiDriverEntryPoint
+
+[Protocols]
+  gEdkIIRedfishConfigHandlerProtocolGuid              ## PRODUCED
+  gEdkIIRedfishFeatureInterchangeDataProtocolGuid     ## CONSUMED
+  gEdkIIRedfishResourceConfigProtocolGuid             ## PRODUCED
+  gEfiRestJsonStructureProtocolGuid                   ## CONSUMED
+
+[Pcd]
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaStringSize
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdMaxRedfishSchemaVersionSize
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport
+
+[Depex]
+  TRUE

--- a/RedfishClientPkg/RedfishClient.fdf.inc
+++ b/RedfishClientPkg/RedfishClient.fdf.inc
@@ -20,6 +20,8 @@
   INF RedfishClientPkg/Features/ComputerSystem/v1_5_0/Dxe/ComputerSystemDxe.inf
   INF RedfishClientPkg/Features/ComputerSystemCollectionDxe/ComputerSystemCollectionDxe.inf
   INF RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.inf
+  INF RedfishClientPkg/Features/PcieDeviceArray/PcieDeviceArrayDxe.inf
+  INF RedfishClientPkg/Features/PcieDevice/v1_9_0/Dxe/PcieDeviceDxe.inf
   INF RedfishClientPkg/HiiToRedfishMemoryDxe/HiiToRedfishMemoryDxe.inf
   INF RedfishClientPkg/HiiToRedfishBootDxe/HiiToRedfishBootDxe.inf
   INF RedfishClientPkg/HiiToRedfishBiosDxe/HiiToRedfishBiosDxe.inf
@@ -36,6 +38,8 @@
   INF RedfishClientPkg/Converter/ComputerSystem/v1_5_0/RedfishComputerSystem_V1_5_0_Dxe.inf
   INF RedfishClientPkg/Converter/ComputerSystemCollection/RedfishComputerSystemCollection_Dxe.inf
   INF RedfishClientPkg/Converter/Bios/v1_0_9/RedfishBios_V1_0_9_Dxe.inf
+  INF RedfishClientPkg/Converter/PCIeDeviceArray/RedfishPCIeDeviceArray_Dxe.inf
+  INF RedfishClientPkg/Converter/PCIeDevice/v1_9_0/RedfishPCIeDevice_V1_9_0_Dxe.inf
   INF RedfishClientPkg/Converter/BootOptionCollection/RedfishBootOptionCollection_Dxe.inf
   INF RedfishClientPkg/Converter/BootOption/v1_0_4/RedfishBootOption_V1_0_4_Dxe.inf
 !endif

--- a/RedfishClientPkg/RedfishClientComponents.dsc.inc
+++ b/RedfishClientPkg/RedfishClientComponents.dsc.inc
@@ -32,6 +32,8 @@
   }
   RedfishClientPkg/Features/ComputerSystemCollectionDxe/ComputerSystemCollectionDxe.inf
   RedfishClientPkg/Features/Bios/v1_0_9/Dxe/BiosDxe.inf
+  RedfishClientPkg/Features/PcieDeviceArray/PcieDeviceArrayDxe.inf
+  RedfishClientPkg/Features/PcieDevice/v1_9_0/Dxe/PcieDeviceDxe.inf
   RedfishClientPkg/Features/BootOptionCollection/BootOptionCollectionDxe.inf
   RedfishClientPkg/Features/BootOption/v1_0_4/Dxe/BootOptionDxe.inf
   RedfishClientPkg/Features/SecureBoot/v1_1_0/Dxe/SecureBootDxe.inf
@@ -46,6 +48,8 @@
   RedfishClientPkg/Converter/ComputerSystem/v1_5_0/RedfishComputerSystem_V1_5_0_Dxe.inf
   RedfishClientPkg/Converter/ComputerSystemCollection/RedfishComputerSystemCollection_Dxe.inf
   RedfishClientPkg/Converter/Bios/v1_0_9/RedfishBios_V1_0_9_Dxe.inf
+  RedfishClientPkg/Converter/PCIeDeviceArray/RedfishPCIeDeviceArray_Dxe.inf
+  RedfishClientPkg/Converter/PCIeDevice/v1_9_0/RedfishPCIeDevice_V1_9_0_Dxe.inf
   RedfishClientPkg/Converter/BootOptionCollection/RedfishBootOptionCollection_Dxe.inf
   RedfishClientPkg/Converter/BootOption/v1_0_4/RedfishBootOption_V1_0_4_Dxe.inf
   RedfishClientPkg/Converter/SecureBoot/v1_1_0/RedfishSecureBoot_V1_1_0_Dxe.inf

--- a/RedfishClientPkg/RedfishClientLibs.dsc.inc
+++ b/RedfishClientPkg/RedfishClientLibs.dsc.inc
@@ -23,6 +23,8 @@
   ComputerSystemV1_5_0Lib|RedfishClientPkg/ConverterLib/edk2library/ComputerSystem/v1_5_0/Lib.inf
   ComputerSystemCollectionLib|RedfishClientPkg/ConverterLib/edk2library/ComputerSystemCollection/Lib.inf
   BiosV1_0_9Lib|RedfishClientPkg/ConverterLib/edk2library/Bios/v1_0_9/Lib.inf
+  PCIeDeviceArrayLib|RedfishClientPkg/ConverterLib/edk2library/PCIeDeviceArray/Lib.inf
+  PCIeDeviceV1_9_0Lib|RedfishClientPkg/ConverterLib/edk2library/PCIeDevice/v1_9_0/Lib.inf
   BootOptionCollectionLib|RedfishClientPkg/ConverterLib/edk2library/BootOptionCollection/Lib.inf
   BootOptionV1_0_4Lib|RedfishClientPkg/ConverterLib/edk2library/BootOption/v1_0_4/Lib.inf
   SecureBootV1_1_0Lib|RedfishClientPkg/ConverterLib/edk2library/SecureBoot/v1_1_0/Lib.inf


### PR DESCRIPTION
# Description
Provision PCIe device information on Redfish service. Using the System topology library to gather the hardware information.

## How This Was Tested
Tested on AMD platform
