### PR TITLE
Disconnect Redfish connection

### DIFF
--- a/RedfishClientPkg/Include/Library/RedfishEventLib.h
+++ b/RedfishClientPkg/Include/Library/RedfishEventLib.h
@@ -2,6 +2,7 @@
   This file defines the Redfish event library interface.
 
   (C) Copyright 2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -51,6 +52,25 @@ CreateAfterProvisioningEvent (
   );
 
 /**
+  Create an EFI event to disconnect the Redfish transport interface.
+
+  @param [in] NotifyFunction                   The notification function to call when the event is signaled.
+  @param [in] NotifyContext                    The content to pass to NotifyFunction when the event is signaled.
+  @param [out] DisconnectRedfishInterfaceEvent  Returns the EFI event returned from gBS->CreateEvent(Ex).
+
+  @retval EFI_SUCCESS       Event was created.
+  @retval Other             Event was not created.
+
+**/
+EFI_STATUS
+EFIAPI
+CreateRedfishInterfaceDisconnectEvent (
+  IN  EFI_EVENT_NOTIFY NotifyFunction, OPTIONAL
+  IN  VOID              *NotifyContext, OPTIONAL
+  OUT EFI_EVENT         *DisconnectRedfishInterfaceEvent
+  );
+
+/**
   Signal ready to provisioning event.
 
   @retval EFI_SUCCESS       Event was created.
@@ -71,6 +91,18 @@ SignalReadyToProvisioningEvent (
 **/
 EFI_STATUS
 SignalAfterProvisioningEvent (
+  IN VOID
+  );
+
+/**
+  Signal disconnect Redfish interface.
+
+  @retval EFI_SUCCESS       Event was created.
+  @retval Other             Event was not created.
+
+**/
+EFI_STATUS
+SignalDisconnectRedfishInterfaceEvent (
   IN VOID
   );
 

--- a/RedfishClientPkg/Library/RedfishEventLib/RedfishEventLib.c
+++ b/RedfishClientPkg/Library/RedfishEventLib/RedfishEventLib.c
@@ -2,6 +2,7 @@
   Redfish event library to deliver Redfish specific event.
 
   (C) Copyright 2022 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -84,6 +85,39 @@ CreateAfterProvisioningEvent (
 }
 
 /**
+  Create an EFI event to disconnect the Redfish transport interface.
+
+  @param [in] NotifyFunction                   The notification function to call when the event is signaled.
+  @param [in] NotifyContext                    The content to pass to NotifyFunction when the event is signaled.
+  @param [out] DisconnectRedfishInterfaceEvent  Returns the EFI event returned from gBS->CreateEvent(Ex).
+
+  @retval EFI_SUCCESS       Event was created.
+  @retval Other             Event was not created.
+
+**/
+EFI_STATUS
+EFIAPI
+CreateRedfishInterfaceDisconnectEvent (
+  IN  EFI_EVENT_NOTIFY NotifyFunction, OPTIONAL
+  IN  VOID              *NotifyContext, OPTIONAL
+  OUT EFI_EVENT         *DisconnectRedfishInterfaceEvent
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = gBS->CreateEventEx (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_CALLBACK,
+                  (NotifyFunction == NULL ? EfiEventEmptyFunction : NotifyFunction),
+                  NotifyContext,
+                  &gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid,
+                  DisconnectRedfishInterfaceEvent
+                  );
+
+  return Status;
+}
+
+/**
   Signal ready to provisioning event.
 
   @retval EFI_SUCCESS       Event was created.
@@ -134,5 +168,31 @@ SignalAfterProvisioningEvent (
   gBS->SignalEvent (Event);
   gBS->CloseEvent (Event);
 
+  return EFI_SUCCESS;
+}
+
+/**
+  Signal disconnect Redfish interface.
+
+  @retval EFI_SUCCESS       Event was created.
+  @retval Other             Event was not created.
+
+**/
+EFI_STATUS
+SignalDisconnectRedfishInterfaceEvent (
+  IN VOID
+  )
+{
+  EFI_STATUS  Status;
+  EFI_EVENT   Event;
+
+  Status = CreateRedfishInterfaceDisconnectEvent (NULL, NULL, &Event);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, failed to create after provisioning event\n", __func__));
+    return Status;
+  }
+
+  gBS->SignalEvent (Event);
+  gBS->CloseEvent (Event);
   return EFI_SUCCESS;
 }

--- a/RedfishClientPkg/Library/RedfishEventLib/RedfishEventLib.inf
+++ b/RedfishClientPkg/Library/RedfishEventLib/RedfishEventLib.inf
@@ -33,10 +33,7 @@
   UefiBootServicesTableLib
   UefiLib
 
-[Protocols]
-
-[Pcd]
-
 [Guids]
   gEfiRedfishClientFeatureReadyToProvisioningGuid
   gEfiRedfishClientFeatureAfterProvisioningGuid
+  gEdkIIRedfisEventRedfishInterfaceDisconnectionGuid

--- a/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.c
+++ b/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.c
@@ -379,6 +379,11 @@ RedfishFeatureDriverStartup (
   }
 
   //
+  // Signal event while we do not need the Redfish connection.
+  //
+  SignalDisconnectRedfishInterfaceEvent ();
+
+  //
   // Restore to the TPL where this callback handler is called.
   //
   gBS->RaiseTPL (REDFISH_FEATURE_CORE_TPL);


### PR DESCRIPTION
# Description
Disconnect Redfish connection when Redfish feature core completes the feature driver dispatching.

The corresponding PR on edk2, https://github.com/tianocore/edk2/pull/12550.
This can close REST EX and the underlying connections, such as HTTP.

## How This Was Tested
Tested on AMD platform
