### PR TITLE
RedfishClientPkg/RedfishFeatureCoreDxe: honor platform disable policy

### DIFF
--- a/RedfishClientPkg/RedfishClientPkg.dec
+++ b/RedfishClientPkg/RedfishClientPkg.dec
@@ -2,7 +2,7 @@
 # Redfish Client Package
 #
 # (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP<BR>
-# Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -79,6 +79,12 @@
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCompatibleSchemaSupport|TRUE|BOOLEAN|0x10000006
   # Limit Redfish feature code driver to one launch.
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCoreExecuteOnce|TRUE|BOOLEAN|0x10000007
+
+[PcdsDynamic]
+  ## When TRUE, RedfishFeatureCoreDxe entry point returns EFI_SUCCESS immediately
+  ## and the Redfish feature stack does not run. Set by platform policy before the
+  ## feature core is dispatched.
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishFeatureCoreDisabled|FALSE|BOOLEAN|0x20000003
 
 [PcdsDynamicEx]
   ## The flag used to indicate that system reboot is required due to system configuration change

--- a/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.c
+++ b/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.c
@@ -3,7 +3,7 @@
   for EDK2 Redfish Feature driver registration.
 
   (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -725,6 +725,11 @@ RedfishFeatureCoreEntryPoint (
   EFI_STATUS  Status;
   EFI_HANDLE  Handle;
   EFI_GUID    *EventGuid;
+
+  if (PcdGetBool (PcdRedfishFeatureCoreDisabled)) {
+    DEBUG ((DEBUG_INFO, "%a: Redfish feature core disabled by platform policy\n", __func__));
+    return EFI_SUCCESS;
+  }
 
   Handle              = NULL;
   ResourceUriNodeList = NULL;

--- a/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.h
+++ b/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.h
@@ -2,7 +2,7 @@
   Definitions of RedfishFeatureCoreDxe
 
   (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -24,6 +24,7 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/RedfishEventLib.h>
 #include <Library/RedfishFeatureUtilityLib.h>
+#include <Library/PcdLib.h>
 #include <Library/ReportStatusCodeLib.h>
 
 #define MaxNodeNameLength             64

--- a/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.inf
+++ b/RedfishClientPkg/RedfishFeatureCoreDxe/RedfishFeatureCoreDxe.inf
@@ -4,7 +4,7 @@
 #  drivers for the registration.
 #
 #  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP<BR>
-#  Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -44,6 +44,7 @@
   UefiDriverEntryPoint
   UefiRuntimeServicesTableLib
   UefiLib
+  PcdLib
   ReportStatusCodeLib
 
 [Protocols]
@@ -55,6 +56,7 @@
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishSystemRebootRequired
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishSystemRebootTimeout
   gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishCoreExecuteOnce
+  gEfiRedfishClientPkgTokenSpaceGuid.PcdRedfishFeatureCoreDisabled
 
 [Depex]
   TRUE


### PR DESCRIPTION
# Description

Introduce PCD PcdRedfishFeatureCoreDisabled which allow platforms to opt out of the Redfish feature stack at boot time. When disabled by platform policy, the feature core exits before installing any protocols or registering any events.

## How This Was Tested

Tested on Arm based system.
